### PR TITLE
Changes to accomodate setting local outgoing address explicitly

### DIFF
--- a/microsoft-azure-storage-samples/pom.xml
+++ b/microsoft-azure-storage-samples/pom.xml
@@ -25,7 +25,7 @@
   <dependency>  
      <groupId>com.microsoft.azure</groupId>
      <artifactId>azure-storage</artifactId>
-     <version>1.3.1</version>
+     <version>1.3.1.1</version>
 </dependency>
 </dependencies>
 </project>

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/Constants.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/Constants.java
@@ -510,7 +510,7 @@ public final class Constants {
         /**
          * Specifies the value to use for UserAgent header.
          */
-        public static final String USER_AGENT_VERSION = "1.3.1";
+        public static final String USER_AGENT_VERSION = "1.3.1.1";
 
         /**
          * The default type for content-type and accept

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
@@ -17,6 +17,7 @@
  */
 package com.microsoft.azure.storage;
 
+import java.net.InetAddress;
 import java.util.Date;
 
 import com.microsoft.azure.storage.core.Utility;
@@ -52,6 +53,11 @@ public abstract class RequestOptions {
     private Long operationExpiryTime;
 
     /**
+     * The optional local address to bind connections to.
+     */
+    private InetAddress localAddress;
+
+    /**
      * Creates an instance of the <code>RequestOptions</code> class.
      */
     public RequestOptions() {
@@ -72,13 +78,14 @@ public abstract class RequestOptions {
             this.setLocationMode(other.getLocationMode());
             this.setMaximumExecutionTimeInMs(other.getMaximumExecutionTimeInMs());
             this.setOperationExpiryTimeInMs(other.getOperationExpiryTimeInMs());
+            this.setLocalAddress(other.getLocalAddress());
         }
     }
 
     /**
      * Populates the default timeout, retry policy, and location mode from client if they are null.
      * 
-     * @param options
+     * @param modifiedOptions
      *            The input options to copy from when applying defaults
      */
     protected static final RequestOptions applyBaseDefaultsInternal(final RequestOptions modifiedOptions) {
@@ -119,6 +126,10 @@ public abstract class RequestOptions {
                 && modifiedOptions.getOperationExpiryTimeInMs() == null && setStartTime) {
             modifiedOptions.setOperationExpiryTimeInMs(new Date().getTime()
                     + modifiedOptions.getMaximumExecutionTimeInMs());
+        }
+
+        if (modifiedOptions.getLocalAddress() == null) {
+            modifiedOptions.setLocalAddress(clientOptions.getLocalAddress());
         }
 
         return modifiedOptions;
@@ -183,6 +194,15 @@ public abstract class RequestOptions {
     }
 
     /**
+     * Gets the local address connections will bind to. May be null.
+     *
+     * @return The current local address.
+     */
+    public InetAddress getLocalAddress() {
+        return this.localAddress;
+    }
+
+    /**
      * Sets the RetryPolicyFactory object to use for this request.
      * <p>
      * The default RetryPolicyFactory is set in the client and is by default {@link RetryExponentialRetry}. You can
@@ -214,7 +234,7 @@ public abstract class RequestOptions {
      * {@link ServiceClient#getDefaultRequestOptions()} object so that all subsequent requests made via the service
      * client will use that server timeout.
      * 
-     * @param timeoutInMs
+     * @param timeoutIntervalInMs
      *            The timeout, in milliseconds, to use for this request.
      */
     public final void setTimeoutIntervalInMs(final Integer timeoutIntervalInMs) {
@@ -268,5 +288,9 @@ public abstract class RequestOptions {
      */
     private void setOperationExpiryTimeInMs(final Long operationExpiryTime) {
         this.operationExpiryTime = operationExpiryTime;
+    }
+
+    public void setLocalAddress(final InetAddress localAddress) {
+        this.localAddress = localAddress;
     }
 }

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpClient.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpClient.java
@@ -1,0 +1,123 @@
+package com.microsoft.azure.storage.http;
+
+import sun.net.www.http.HttpClient;
+import sun.net.www.protocol.http.HttpURLConnection;
+import sun.util.logging.PlatformLogger;
+
+import java.io.IOException;
+import java.net.*;
+
+public class AzureHttpClient extends HttpClient {
+    private boolean inCacheOverride;
+    private final InetAddress localAddress;
+
+    private AzureHttpClient(URL url, Proxy p, InetAddress localAddress, int to) throws IOException {
+        this.localAddress = localAddress;
+
+        proxy = (p == null) ? Proxy.NO_PROXY : p;
+        this.host = url.getHost();
+        this.url = url;
+        port = url.getPort();
+        if (port == -1) {
+            port = getDefaultPort();
+        }
+        setConnectTimeout(to);
+
+        openServer();
+    }
+
+    public static HttpClient New(URL url, Proxy p, InetAddress localAddress, int to, boolean useCache) throws IOException {
+        if (p == null) {
+            p = Proxy.NO_PROXY;
+        }
+
+        AzureHttpClient ret = null;
+        /* see if one's already around */
+        if (useCache) {
+            HttpClient cachedClient = kac.get(url, null);
+            if (cachedClient != null) {
+                if (cachedClient instanceof AzureHttpClient) {
+                    ret = (AzureHttpClient)cachedClient;
+                    if ((ret.localAddress != null && ret.localAddress.equals(localAddress))
+                            || (ret.localAddress == null && localAddress == null)
+                            || (ret.proxy != null && ret.proxy.equals(p))
+                            || (ret.proxy == null && p == null)) {
+                        synchronized (ret) {
+                            ret.cachedHttpClient = true;
+                            assert ret.inCacheOverride;
+                            ret.inCacheOverride = false;
+                            PlatformLogger logger = HttpURLConnection.getHttpLogger();
+                            if (logger.isLoggable(PlatformLogger.FINEST)) {
+                                logger.finest("KeepAlive stream retrieved from the cache, " + ret);
+                            }
+                        }
+                    } else {
+                        // We cannot return this connection to the cache as it's
+                        // KeepAliveTimeout will get reset. We simply close the connection.
+                        // This should be fine as it is very rare that a connection
+                        // to the same host will not use the same proxy.
+                        synchronized (ret) {
+                            ret.inCacheOverride = false;
+                            ret.closeServer();
+                        }
+                        ret = null;
+                    }
+                } else {
+                    // We would hope that this won't happen - outgoing connections to Azure URLs should
+                    // always go through this class. If for some reason it does happen, try to close
+                    // the connection and make a new one.
+                    synchronized (cachedClient) {
+                        cachedClient.closeServer();
+                    }
+                    ret = null;
+                }
+            }
+        }
+        if (ret == null) {
+            ret = new AzureHttpClient(url, p, localAddress, to);
+        } else {
+            SecurityManager security = System.getSecurityManager();
+            if (security != null) {
+                    if (ret.proxy == Proxy.NO_PROXY || ret.proxy == null) {
+                            security.checkConnect(InetAddress.getByName(url.getHost()).getHostAddress(), url.getPort());
+                        } else {
+                            security.checkConnect(url.getHost(), url.getPort());
+                        }
+                }
+            ret.url = url;
+        }
+        return ret;
+    }
+
+    public static HttpClient New(URL url, Proxy p, InetAddress localAddress, int to) throws IOException {
+        return New(url, p, localAddress, to, true);
+    }
+
+    public static HttpClient New(URL url, String proxyHost, int proxyPort, InetAddress localAddress, boolean useCache, int to) throws IOException {
+        return New(url, newHttpProxy(proxyHost, proxyPort, "http"), localAddress, to, useCache);
+    }
+
+    @Override
+    protected synchronized void putInKeepAliveCache() {
+        if (inCacheOverride) {
+            return;
+        }
+        inCacheOverride = true;
+        kac.put(url, null, this);
+    }
+
+    @Override
+    protected boolean isInKeepAliveCache() {
+        return inCacheOverride;
+    }
+
+    @Override
+    protected Socket createSocket() throws IOException {
+        Socket s = super.createSocket();
+        if (localAddress != null) {
+            InetSocketAddress localSocketAddress = new InetSocketAddress(localAddress, 0);
+            s.bind(localSocketAddress);
+        }
+        return s;
+    }
+}

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpHandler.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpHandler.java
@@ -1,0 +1,28 @@
+package com.microsoft.azure.storage.http;
+
+import com.microsoft.azure.storage.http.AzureHttpURLConnection;
+import sun.net.www.protocol.http.Handler;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Proxy;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class AzureHttpHandler extends Handler {
+    private final InetAddress localAddress;
+
+    public AzureHttpHandler(InetAddress localAddress) {
+        this.localAddress = localAddress;
+    }
+
+    @Override
+    protected URLConnection openConnection(URL u) throws IOException {
+        return openConnection(u, null);
+    }
+
+    @Override
+    protected URLConnection openConnection(URL u, Proxy p) throws IOException {
+        return new AzureHttpURLConnection(u, p, localAddress, this);
+    }
+}

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpURLConnection.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpURLConnection.java
@@ -1,0 +1,42 @@
+package com.microsoft.azure.storage.http;
+
+import sun.net.www.http.HttpClient;
+import sun.net.www.protocol.http.Handler;
+import sun.net.www.protocol.http.HttpURLConnection;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Proxy;
+import java.net.URL;
+
+public class AzureHttpURLConnection extends HttpURLConnection {
+    private final InetAddress localAddress;
+
+    AzureHttpURLConnection(URL u, Proxy p, InetAddress localAddress, Handler handler) {
+        super(u, p, handler);
+        this.localAddress = localAddress;
+    }
+
+    @Override
+    protected void setNewClient(URL url, boolean useCache) throws IOException {
+        proxiedConnect(url, null, -1, useCache);
+    }
+
+    @Override
+    protected void proxiedConnect(URL url, String proxyHost, int proxyPort, boolean useCache) throws IOException {
+        int connectTimeout = http.getConnectTimeout();
+        int readTimeout = http.getReadTimeout();
+        http = AzureHttpClient.New(url, proxyHost, proxyPort, localAddress, useCache, connectTimeout);
+        http.setReadTimeout(readTimeout);
+    }
+
+    @Override
+    protected HttpClient getNewHttpClient(URL url, Proxy p, int connectTimeout) throws IOException {
+        return AzureHttpClient.New(url, p, localAddress, connectTimeout);
+    }
+
+    @Override
+    protected HttpClient getNewHttpClient(URL url, Proxy p, int connectTimeout, boolean useCache) throws IOException {
+        return AzureHttpClient.New(url, p, localAddress, connectTimeout, useCache);
+    }
+}

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpsHandler.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureHttpsHandler.java
@@ -1,0 +1,105 @@
+package com.microsoft.azure.storage.http;
+
+import sun.net.www.protocol.https.Handler;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.*;
+import java.util.Objects;
+
+public class AzureHttpsHandler extends Handler {
+    private final InetAddress localAddress;
+
+    public AzureHttpsHandler(InetAddress localAddress) {
+        this.localAddress = localAddress;
+    }
+
+    @Override
+    protected URLConnection openConnection(URL u) throws IOException {
+        return openConnection(u, null);
+    }
+
+    @Override
+    protected URLConnection openConnection(URL u, Proxy p) throws IOException {
+        HttpsURLConnection conn = (HttpsURLConnection) super.openConnection(u, p);
+        if (localAddress != null) {
+            conn.setSSLSocketFactory(new BindingSSLSocketFactory(localAddress));
+        }
+        return conn;
+    }
+
+    private static class BindingSSLSocketFactory extends SSLSocketFactory {
+        private final SSLSocketFactory delegate;
+        private final InetAddress localAddress;
+
+        private BindingSSLSocketFactory(InetAddress localAddress) {
+            this.delegate = (SSLSocketFactory) SSLSocketFactory.getDefault();
+            this.localAddress = localAddress;
+        }
+
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return delegate.getDefaultCipherSuites();
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return delegate.getSupportedCipherSuites();
+        }
+
+        @Override
+        public Socket createSocket() throws IOException {
+            Socket s = delegate.createSocket();
+            s.bind(new InetSocketAddress(localAddress, 0));
+            return s;
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            Socket s = delegate.createSocket(host, port);
+            s.bind(new InetSocketAddress(localAddress, 0));
+            return s;
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+            return delegate.createSocket(host, port, localHost, localPort);
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            Socket s = delegate.createSocket(host, port);
+            s.bind(new InetSocketAddress(localAddress, 0));
+            return s;
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port, InetAddress localAddress, int localPort) throws IOException {
+            return delegate.createSocket(host, port, localAddress, localPort);
+        }
+
+        @Override
+        public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+            return delegate.createSocket(s, host, port, autoClose);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(delegate, localAddress);
+        }
+
+        @Override
+        public boolean equals(Object that) {
+            if (this == that) {
+                return true;
+            }
+            if (that instanceof BindingSSLSocketFactory) {
+                BindingSSLSocketFactory thatBindingSSLSocketFactory = (BindingSSLSocketFactory) that;
+                return delegate.equals(thatBindingSSLSocketFactory.delegate)
+                        && localAddress.equals(thatBindingSSLSocketFactory.localAddress);
+            }
+            return false;
+        }
+    }
+}

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureStreamHandlerFactory.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/http/AzureStreamHandlerFactory.java
@@ -1,0 +1,57 @@
+package com.microsoft.azure.storage.http;
+
+import com.microsoft.azure.storage.Constants;
+
+import java.net.InetAddress;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class AzureStreamHandlerFactory implements URLStreamHandlerFactory {
+    private static final AzureStreamHandlerFactory instance = new AzureStreamHandlerFactory();
+
+    private Map<InetAddress, URLStreamHandler> httpHandlerMap = new ConcurrentHashMap<InetAddress, URLStreamHandler>();
+    private Map<InetAddress, URLStreamHandler> httpsHandlerMap = new ConcurrentHashMap<InetAddress, URLStreamHandler>();
+
+    public static AzureStreamHandlerFactory getInstance() {
+        return instance;
+    }
+
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        return createURLStreamHandler(protocol, null);
+    }
+
+    public URLStreamHandler createURLStreamHandler(String protocol, InetAddress localAddress) {
+        if (Constants.HTTP.equalsIgnoreCase(protocol)) {
+            return getHandler(localAddress, false);
+        }
+        if (Constants.HTTPS.equalsIgnoreCase(protocol)) {
+            return getHandler(localAddress, true);
+        }
+        return null;
+    }
+
+    private URLStreamHandler getHandler(InetAddress addr, boolean isHttps) {
+        URLStreamHandler handler;
+        if (isHttps) {
+            handler = httpsHandlerMap.get(addr);
+        } else {
+            handler = httpHandlerMap.get(addr);
+        }
+        if (handler != null) {
+            return handler;
+        }
+
+        if (isHttps) {
+            handler = new AzureHttpsHandler(addr);
+            httpsHandlerMap.put(addr, handler);
+        } else {
+            handler = new AzureHttpHandler(addr);
+            httpHandlerMap.put(addr, handler);
+        }
+
+        return handler;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>azure-storage</artifactId>
-	<version>1.3.1</version>
+	<version>1.3.1.1</version>
 	<packaging>jar</packaging>
 
 	<name>Microsoft Azure Storage Client SDK</name>


### PR DESCRIPTION
This is a follow up an issue raised by a colleague. See the following:
[Unable to set local interface IP on outgoing Azure connections] (https://github.com/Azure/azure-storage-java/issues/27)
[Binding specific interface IP address to Azure Storage container connections] (http://stackoverflow.com/questions/26802636/binding-specific-interface-ip-address-to-azure-storage-container-connections)

We forked the azure-storage repository in order to incorporate the needed capability to set the local network interface when creating connections. The changes are described below.

New Classes

The internal mechanics of the URLStreamHandler for http and https connections were mirrored up to the point where the socket is created by effectively duplicating the functionality of the internal implementations of HttpURLConnection and HttpsURLConnection within OpenJDK Java 7.

AzureStreamHandlerFactory

Holds a cache of URLStreamHandler instances based on the combination of protocol and local address to be used.

AzureHttpHandler

Extends the internal implementation class sun.net.www.protocol.http.handler.

The modified behavior is to override the openConnection method to return an AzureHttpURLConnection instance.

AzureHttpsHandler

Extends the internal implementation class sun.net.www.protocol.https.handler.

The modified behavior is to override the openConnection method. It delegates to the super class, and then explicitly sets the SSLSocketFactory on the returned connection object before handing it back to the caller. The internal HttpsURLConnection implementation always invokes its SSLSocketFactory to create sockets, so replacing that with a factory that always binds the socket to the correct local address is sufficient to handle HTTPS connections.

AzureHttpURLConnection

Extends the internal implementation class sun.net.www.protocol.http.HttpURLConnection.

Overrides all methods which produce HttpClient instances to produce AzureHttpClient instances instead.

AzureHttpClient

Extends the internal implementation class sun.net.www.http.HttpClient.

Constructor logic was copied from the super class because the constructor calls openServer (which creates a socket), and the local address needs to be set first. Mirrors the functionality of the super class's New methods, except they produce AzureHttpClient instances. Overrides the keep alive cache mechanisms because the variable that drives it is private and cannot be accessed in the subclass. Overrides the createSocket method to look at the local address and bind it to the socket before returning.

Modified Classes

The following describes the changes to existing Azure SDK classes.

RequestOptions

Adds a new option to set the local IP address to be used for client connections. Follows the existing pattern the class uses.

BaseRequest

Modifies the createURLConnection method. When a local address has been set, instead of using the URI.toURL() method, the URL is formed by using the constructor that accepts a URLStreamHandler parameter and invoking the AzureStreamHandlerFactory to produce a handler instance.