### PR TITLE
Update QueueMessageSerializer.java

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/RetryInfo.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/RetryInfo.java
@@ -53,6 +53,7 @@ public class RetryInfo {
     public RetryInfo(RetryContext retryContext) {
         Utility.assertNotNull("retryContext", retryContext);
         this.targetLocation = retryContext.getNextLocation();
+		
         this.updatedLocationMode = retryContext.getLocationMode();
     }
 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/queue/QueueMessageSerializer.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/queue/QueueMessageSerializer.java
@@ -28,7 +28,7 @@ import com.microsoft.azure.storage.core.Utility;
  * RESERVED FOR INTERNAL USE. A class used to serialize message requests to a byte array.
  */
 final class QueueMessageSerializer {
-
+    static final XMLOutputFactory xmlOutFactoryInst = XMLOutputFactory.newInstance();
     /**
      * Generates the message request body from a string containing the message.
      * The message must be encodable as UTF-8. To be included in a web request,
@@ -47,7 +47,6 @@ final class QueueMessageSerializer {
      */
     public static byte[] generateMessageRequestBody(final String message) throws XMLStreamException, StorageException {
         final StringWriter outWriter = new StringWriter();
-        final XMLOutputFactory xmlOutFactoryInst = XMLOutputFactory.newInstance();
         final XMLStreamWriter xmlw = xmlOutFactoryInst.createXMLStreamWriter(outWriter);
 
         // default is UTF8


### PR DESCRIPTION
set XMLOutputFactory as static. 
---
Create XMLOutputFactory is heavy operation. call it frequently can cause high CPU and low throughput issue.

https://github.com/Azure/azure-storage-java/issues/36