### PR TITLE
Add listBlobs overload for parity with .NET SDK

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlobContainer.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlobContainer.java
@@ -1062,6 +1062,23 @@ public final class CloudBlobContainer {
     }
 
     /**
+     * Returns an enumerable collection of blob items for the container whose names begin with the specified prefix.
+     * 
+     * @param prefix
+     *            A <code>String</code> that represents the blob name prefix. This value must be preceded either by the
+     *            name of the container or by the absolute path to the container.
+     * @param useFlatBlobListing
+     *            <code>true</code> to indicate that the returned list will be flat; <code>false</code> to indicate that
+     *            the returned list will be hierarchical.
+     * @return An enumerable collection of {@link ListBlobItem} objects retrieved lazily that represents the
+     *         items whose names begin with the specified prefix in this container.
+     */
+    @DoesServiceRequest
+    public Iterable<ListBlobItem> listBlobs(final String prefix, final boolean useFlatBlobListing) {
+        return this.listBlobs(prefix, useFlatBlobListing, EnumSet.noneOf(BlobListingDetails.class), null, null);
+    }
+
+    /**
      * Returns an enumerable collection of blob items whose names begin with the specified prefix, using the specified
      * flat or hierarchical option, listing details options, request options, and operation context.
      * 


### PR DESCRIPTION
Add listBlobs(prefix, useFlatBlobListing) overload to be more on par with .NET SDK.