### PR TITLE
Remove redundant throws clause in CloudBlob#getName().

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
@@ -2016,10 +2016,8 @@ public abstract class CloudBlob implements ListBlobItem {
      *
      * @return A <code>String</code> that represents the name of the blob.
      *
-     * @throws URISyntaxException
-     *             If the resource URI is invalid.
      */
-    public final String getName() throws URISyntaxException {
+    public final String getName() {
         return this.name;
     }
 


### PR DESCRIPTION
CloudBlob#getName() method has redundant throws clause and remove it.
