### PR TITLE
Fix guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Be sure to check out the Microsoft Azure [Developer Forums on MSDN](http://socia
 
 #Contribute Code or Provide Feedback
 
-If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines.html).
+If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines/).
 
 If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-storage-java/issues) section of the project.
 


### PR DESCRIPTION
It changed to http://azure.github.io/guidelines/