### PR TITLE
Update the read buffer size of BlobInputStream according to the read length

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/Constants.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/Constants.java
@@ -1026,7 +1026,12 @@ public final class Constants {
     /**
      * The default minimum read size, in bytes, for a {@link BlobInputStream} or {@link FileInputStream}.
      */
-    public static final int DEFAULT_MINIMUM_READ_SIZE_IN_BYTES = Constants.MAX_BLOCK_SIZE;
+    public static final int DEFAULT_MINIMUM_READ_SIZE_IN_BYTES = Constants.MAX_BLOCK_SIZE / 8;
+
+    /**
+     * The default maximum read size, in bytes, for a {@link BlobInputStream} or {@link FileInputStream}.
+     */
+    public static final int DEFAULT_MAXIMUM_READ_SIZE_IN_BYTES = Constants.MAX_BLOCK_SIZE;
 
     /**
      * The maximum size, in bytes, of a given stream mark operation.

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
@@ -109,6 +109,11 @@ public abstract class CloudBlob implements ListBlobItem {
     protected int streamMinimumReadSizeInBytes = Constants.DEFAULT_MINIMUM_READ_SIZE_IN_BYTES;
 
     /**
+     * Holds the maximum read size when using a {@link BlobInputStream}.
+     */
+    protected int streamMaximumReadSizeInBytes = Constants.DEFAULT_MAXIMUM_READ_SIZE_IN_BYTES;
+
+    /**
      * Represents the blob client.
      */
     protected CloudBlobClient blobServiceClient;
@@ -2147,6 +2152,16 @@ public abstract class CloudBlob implements ListBlobItem {
      */
     public final int getStreamMinimumReadSizeInBytes() {
         return this.streamMinimumReadSizeInBytes;
+    }
+
+    /**
+     * Returns the maximum read size when using a {@link BlobInputStream}.
+     *
+     * @return A <code>int</code> which represents the maximum read size, in bytes, when using a {@link BlobInputStream}
+     *         object.
+     */
+    public final int getStreamMaximumReadSizeInBytes() {
+        return this.streamMaximumReadSizeInBytes;
     }
 
     /**

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
@@ -2550,6 +2550,23 @@ public abstract class CloudBlob implements ListBlobItem {
         this.streamMinimumReadSizeInBytes = minimumReadSize;
     }
 
+    /**
+     * Sets the maximum read size when using a {@link BlobInputStream}.
+     *
+     * @param maximumReadSize
+     *            An <code>int</code> that represents the maximum block size, in bytes, for reading from a blob while
+     *            using a {@link BlobInputStream} object. Must be less than or equal to 4M.
+     * @throws IllegalArgumentException
+     *             If <code>maximumReadSize</code> is less than or equal to 4 M.
+     */
+    public void setStreamMaximumReadSizeInBytes(final int maximumReadSize) {
+        if (maximumReadSize > 4 * Constants.MB) {
+            throw new IllegalArgumentException("MaximumReadSize");
+        }
+
+        this.streamMaximumReadSizeInBytes = maximumReadSize;
+    }
+
     protected void updateEtagAndLastModifiedFromResponse(HttpURLConnection request) {
         // ETag
         this.getProperties().setEtag(request.getHeaderField(Constants.HeaderConstants.ETAG));


### PR DESCRIPTION
By default, the read buffer size of BlobInputStream is 4M, which is optimized for high throughput apps, but not for low-latency apps.  Through we can set the minimumReadSize to some small value, it will waste more RPCs when read bytes is more than the minimumReadSize. 

A trade-off is to update the read buffer size of BlobInputStream according to the read length. By adding an option: maximumReadSize, if when the requested length of data is less than maximumReadSize and more than minimumReadSize,  the client will try to read the  the requested length of data from the server.  It will help to reduce the latency of random read.

Suggestions are welcomed~

PS: there are so many failed tests when testing the sdk?  Is there some docs about how to run the tests in local.  Tests about this issue will be added later~
