### PR TITLE
Fixed wrongful 0ms retry intervals

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/ExecutionEngine.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/ExecutionEngine.java
@@ -115,11 +115,13 @@ public final class ExecutionEngine {
                 currResult.setStartDate(new Date());
 
                 Logger.info(opContext, LogConstants.GET_RESPONSE);
+                try {
+                    currResult.setStatusCode(request.getResponseCode());
+                    currResult.setStatusMessage(request.getResponseMessage());
+                } finally {
+                    currResult.setStopDate(new Date());
+                }
 
-                currResult.setStatusCode(request.getResponseCode());
-                currResult.setStatusMessage(request.getResponseMessage());
-
-                currResult.setStopDate(new Date());
                 currResult.setServiceRequestID(BaseResponse.getRequestId(request));
                 currResult.setEtag(BaseResponse.getEtag(request));
                 currResult.setRequestDate(BaseResponse.getDate(request));


### PR DESCRIPTION
If a `SocketException` is thrown while waiting for a response, the result's `stopDate` won't be set and thus will be `null`; it is then propagated to `RetryPolicy.lastPrimaryAttempt`, which is used to determine the next retry interval.