### PR TITLE
Minor CPU optimizations for listStatus

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Canonicalizer.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Canonicalizer.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.microsoft.azure.storage.Constants;
 import com.microsoft.azure.storage.StorageException;
@@ -44,6 +46,8 @@ abstract class Canonicalizer {
      * The expected length for the canonicalized string when SharedKeyFull is used to sign table requests.
      */
     private static final int ExpectedTableCanonicalizedStringLength = 200;
+
+    private static final Pattern CRLF  = Pattern.compile("\r\n", Pattern.LITERAL);
 
     /**
      * Add x-ms- prefixed headers in a fixed order.
@@ -85,7 +89,8 @@ abstract class Canonicalizer {
                 }
 
                 // Unfolding is simply removal of CRLF.
-                final String unfoldedValue = value.replace("\r\n", Constants.EMPTY_STRING);
+                final String unfoldedValue = CRLF.matcher(value)
+                    .replaceAll(Matcher.quoteReplacement(Constants.EMPTY_STRING));
 
                 // Append it to the canonicalized element string.
                 canonicalizedElement.append(delimiter);
@@ -251,6 +256,11 @@ abstract class Canonicalizer {
         final StringBuilder canonicalizedResource = new StringBuilder(resourcepath.toString());
 
         // query parameters
+        if (address.getQuery()!= null  && !address.getQuery().contains("=")) {
+            //no query params. Safe to return empty
+            return canonicalizedResource.toString();
+        }
+
         final Map<String, String[]> queryVariables = PathUtility.parseQueryString(address.getQuery());
 
         final Map<String, String> lowercasedKeyNameValue = new HashMap<String, String>();

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Canonicalizer.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Canonicalizer.java
@@ -256,8 +256,8 @@ abstract class Canonicalizer {
         final StringBuilder canonicalizedResource = new StringBuilder(resourcepath.toString());
 
         // query parameters
-        if (address.getQuery()!= null  && !address.getQuery().contains("=")) {
-            //no query params. Safe to return empty
+        if (address.getQuery() == null  || !address.getQuery().contains("=")) {
+            //no query params.
             return canonicalizedResource.toString();
         }
 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Utility.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Utility.java
@@ -73,10 +73,10 @@ import com.microsoft.azure.storage.StorageExtendedErrorInformation;
  */
 public final class Utility {
 
-    private static ThreadLocal<org.joda.time.format.DateTimeFormatter>
-        RFC1123_GMT_DATE_TIME_FORMATTER = new ThreadLocal<org.joda.time.format.DateTimeFormatter>() {
+    private static ThreadLocal<DateTimeFormatter>
+        RFC1123_GMT_DATE_TIME_FORMATTER = new ThreadLocal<DateTimeFormatter>() {
         @Override protected DateTimeFormatter initialValue() {
-            return org.joda.time.format.DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'")
+            return DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'")
                 .withZoneUTC().withLocale(Locale.US);
         }
     };
@@ -574,7 +574,7 @@ public final class Utility {
      * @return A <code>String</code> that represents the current GMT date/time using the RFC1123 pattern.
      */
     public static String getGMTTime() {
-        return getGMTTime(new org.joda.time.DateTime());
+        return getGMTTime(new DateTime());
     }
 
     /**
@@ -602,7 +602,7 @@ public final class Utility {
      * @return A <code>String</code> that represents the GMT date/time for the specified value using the RFC1123
      *         pattern.
      */
-    public static String getGMTTime(final org.joda.time.DateTime date) {
+    public static String getGMTTime(final DateTime date) {
         StringBuilder sb = new StringBuilder(50);
         RFC1123_GMT_DATE_TIME_FORMATTER.get().printTo(sb, date);
         return sb.toString();

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 			<version>0.8.0</version>
 			<scope>test</scope>
 		</dependency>
-    </dependencies>
+	</dependencies>
 
 	<build>
 		<sourceDirectory>microsoft-azure-storage/src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -81,11 +81,6 @@
 			<version>0.8.0</version>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-            <version>2.9.4</version>
-        </dependency>
     </dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,12 @@
 			<version>0.8.0</version>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+            <version>2.9.4</version>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<sourceDirectory>microsoft-azure-storage/src</sourceDirectory>


### PR DESCRIPTION
During listStatus, couple of expensive methods showed up in profiler. Patch addresses those minor CPU optimizations codepaths. With the patch, following methods do not show up anymore as expensive methods.

1. SAXParser initializations. In SAXParser init, this ended up scanning for jar file entries.
<img width="101" alt="saxparser_screenshot" src="https://cloud.githubusercontent.com/assets/323339/25956781/45301efe-368a-11e7-8000-33e38424e7e8.png">

2. DateFormat showed up. CPU usage can be reduced with JODA time.