### PR TITLE
Ensure ResponseReceivedEvent fires when there are network errors

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/StorageException.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/StorageException.java
@@ -98,8 +98,11 @@ public class StorageException extends Exception {
             Utility.logHttpError(translatedException, opContext);
             return translatedException;
         } else {
+            String message = (responseCode == 0)
+                ? "The connection was terminated."
+                : "The server encountered an unknown failure: ".concat(responseMessage);
             return new StorageException(StorageErrorCode.SERVICE_INTERNAL_ERROR.toString(),
-                    "The server encountered an unknown failure: ".concat(responseMessage),
+                    message,
                     HttpURLConnection.HTTP_INTERNAL_ERROR, null, cause);   
         }
     }

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/ExecutionEngine.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/ExecutionEngine.java
@@ -97,42 +97,46 @@ public final class ExecutionEngine {
                 Logger.info(opContext, LogConstants.START_REQUEST, request.getURL(),
                         request.getRequestProperty(Constants.HeaderConstants.DATE));
 
-                // 5. Potentially upload data
-                if (task.getSendStream() != null) {
-                    Logger.info(opContext, LogConstants.UPLOAD);
-                    final StreamMd5AndLength descriptor = Utility.writeToOutputStream(task.getSendStream(),
-                            request.getOutputStream(), task.getLength(), false /* rewindStream */,
-                            false /* calculate MD5 */, opContext, task.getRequestOptions());
-
-                    task.validateStreamWrite(descriptor);
-                    Logger.info(opContext, LogConstants.UPLOADDONE);
-                }
-
-                Utility.logHttpRequest(request, opContext);
-
-                // 6. Process the request - Get response
                 RequestResult currResult = task.getResult();
-                currResult.setStartDate(new Date());
+                // Ensure startDate and stopDate are set and the ResponseReceivedEvent is raised even if
+                // there are network errors while the request body is sent or the response body is received.
+                try {
+                    currResult.setStartDate(new Date());
 
-                Logger.info(opContext, LogConstants.GET_RESPONSE);
+                    // 5. Potentially upload data
+                    if (task.getSendStream() != null) {
+                        Logger.info(opContext, LogConstants.UPLOAD);
+                        final StreamMd5AndLength descriptor = Utility.writeToOutputStream(task.getSendStream(),
+                                request.getOutputStream(), task.getLength(), false /* rewindStream */,
+                                false /* calculate MD5 */, opContext, task.getRequestOptions());
 
-                currResult.setStatusCode(request.getResponseCode());
-                currResult.setStatusMessage(request.getResponseMessage());
-                currResult.setStopDate(new Date());
+                        task.validateStreamWrite(descriptor);
+                        Logger.info(opContext, LogConstants.UPLOADDONE);
+                    }
 
-                currResult.setServiceRequestID(BaseResponse.getRequestId(request));
-                currResult.setEtag(BaseResponse.getEtag(request));
-                currResult.setRequestDate(BaseResponse.getDate(request));
-                currResult.setContentMD5(BaseResponse.getContentMD5(request));
+                    Utility.logHttpRequest(request, opContext);
 
-                // 7. Fire ResponseReceived Event
-                ExecutionEngine.fireResponseReceivedEvent(opContext, request, task.getResult());
+                    // 6. Process the request - Get response
+                    Logger.info(opContext, LogConstants.GET_RESPONSE);                
+                    currResult.setStatusCode(request.getResponseCode());
+                    currResult.setStatusMessage(request.getResponseMessage());
+                    currResult.setServiceRequestID(BaseResponse.getRequestId(request));
+                    currResult.setEtag(BaseResponse.getEtag(request));
+                    currResult.setRequestDate(BaseResponse.getDate(request));
+                    currResult.setContentMD5(BaseResponse.getContentMD5(request));
+                }
+                finally {
+                    currResult.setStopDate(new Date());
 
-                Logger.info(opContext, LogConstants.RESPONSE_RECEIVED, currResult.getStatusCode(),
-                        currResult.getServiceRequestID(), currResult.getContentMD5(), currResult.getEtag(),
-                        currResult.getRequestDate());
-               
-                Utility.logHttpResponse(request, opContext);   
+                    // 7. Fire ResponseReceived Event
+                    ExecutionEngine.fireResponseReceivedEvent(opContext, request, task.getResult());
+
+                    Logger.info(opContext, LogConstants.RESPONSE_RECEIVED, currResult.getStatusCode(),
+                                currResult.getServiceRequestID(), currResult.getContentMD5(), currResult.getEtag(),
+                                currResult.getRequestDate());
+
+                    Utility.logHttpResponse(request, opContext);
+                }
 
                 // 8. Pre-process response to check if there was an exception. Do Response parsing (headers etc).
                 Logger.info(opContext, LogConstants.PRE_PROCESS);


### PR DESCRIPTION
Ensure that the ResponseReceivedEvent fires even when the connection is terminated by the service.

I discovered this event was not firing while trying to collect metrics for a scenario that exceeds
the storage account maximum ingress limit.