### PR TITLE
thread pool in BlobOutputStreamInternal should be daemon

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobOutputStreamInternal.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobOutputStreamInternal.java
@@ -62,7 +62,7 @@ final class BlobOutputStreamInternal extends BlobOutputStream {
             Thread t = new Thread(group, r,
                     namePrefix + threadNumber.getAndIncrement(),
                     0);
-            t.setDaemon(false);
+            t.setDaemon(true);
             if (t.getPriority() != Thread.NORM_PRIORITY)
                 t.setPriority(Thread.NORM_PRIORITY);
             return t;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobOutputStreamInternal.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobOutputStreamInternal.java
@@ -27,13 +27,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.microsoft.azure.storage.AccessCondition;
 import com.microsoft.azure.storage.Constants;
@@ -50,6 +45,29 @@ import com.microsoft.azure.storage.core.Utility;
  * The class is an append-only stream for writing into storage.
  */
 final class BlobOutputStreamInternal extends BlobOutputStream {
+
+    private static class BlobOutputStreamThreadFactory implements ThreadFactory {
+        private final ThreadGroup group;
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+
+        BlobOutputStreamThreadFactory() {
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() :
+                    Thread.currentThread().getThreadGroup();
+            namePrefix = "azure-storage-bloboutputstream-thread-";
+        }
+
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(group, r,
+                    namePrefix + threadNumber.getAndIncrement(),
+                    0);
+            t.setDaemon(false);
+            if (t.getPriority() != Thread.NORM_PRIORITY)
+                t.setPriority(Thread.NORM_PRIORITY);
+            return t;
+        }
+    }
 
     /**
      * Holds the {@link AccessCondition} object that represents the access conditions for the blob.
@@ -171,9 +189,10 @@ final class BlobOutputStreamInternal extends BlobOutputStream {
         this.threadExecutor = new ThreadPoolExecutor(
                 this.options.getConcurrentRequestCount(),
                 this.options.getConcurrentRequestCount(),
-                10, 
+                10,
                 TimeUnit.SECONDS,
-                new LinkedBlockingQueue<Runnable>());
+                new LinkedBlockingQueue<Runnable>(),
+                new BlobOutputStreamThreadFactory());
         this.completionService = new ExecutorCompletionService<Void>(this.threadExecutor);
     }
 


### PR DESCRIPTION
I am from HDI@Azure team. Recently we found a bug that in some of Spark applications, after all jobs are done and main thread is quit, the JVM process is still hanging there. 

I used jstack to detect any non-daemon thread is hanging and found the following one:

```
"pool-21-thread-1" #90 prio=5 os_prio=0 tid=0x00007f2e2c0d0000 nid=0x78ed waiting on condition [0x00007f2e1c4e5000]
   java.lang.Thread.State: WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000000c47a4f60> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1074)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

To track who create this thread pool, Memory Analyzer told me the following info:

![image](https://user-images.githubusercontent.com/678008/30044565-a70c39e0-91b2-11e7-8a03-3ba4ad411a5a.png)

This PR fixes the above issue