### PR TITLE
Reduces the number of JavaDoc warnings from 89 to 3 in azure-storage-…

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/AccessCondition.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/AccessCondition.java
@@ -346,9 +346,6 @@ public final class AccessCondition {
      * @param request
      *            A <code>java.net.HttpURLConnection</code> object that represents the request to which the condition is
      *            being applied.
-     * 
-     * @throws StorageException
-     *             If there is an error parsing the date value of the access condition.
      */
     public void applyAppendConditionToRequest(final HttpURLConnection request) {
         if (this.ifMaxSizeLessThanOrEqual != null) {

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/LoggingProperties.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/LoggingProperties.java
@@ -27,7 +27,7 @@ public final class LoggingProperties {
     private String version = "1.0";
 
     /**
-     * An <code>EnumSet<code> of <code>LoggingOperations</code> that represents which storage operations should be logged.
+     * An <code>EnumSet</code> of <code>LoggingOperations</code> that represents which storage operations should be logged.
      */
     private EnumSet<LoggingOperations> logOperationTypes = EnumSet.noneOf(LoggingOperations.class);
 
@@ -37,9 +37,9 @@ public final class LoggingProperties {
     private Integer retentionIntervalInDays;
 
     /**
-     * Gets an <code>EnumSet<code> of <code>{@link LoggingOperations}</code> that represents which storage operations should be logged.
+     * Gets an <code>EnumSet</code> of <code>{@link LoggingOperations}</code> that represents which storage operations should be logged.
      * 
-     * @return An <code>EnumSet<code> of <code>{@link LoggingOperations}</code>.
+     * @return An <code>EnumSet</code> of <code>{@link LoggingOperations}</code>.
      */
     public EnumSet<LoggingOperations> getLogOperationTypes() {
         return this.logOperationTypes;
@@ -67,7 +67,7 @@ public final class LoggingProperties {
      * Sets the <code>{@link LoggingOperations}</code> for which storage operations should be logged.
      * 
      * @param logOperationTypes
-     *        An <code>EnumSet<code> of <code>{@link LoggingOperations}</code> to set.
+     *        An <code>EnumSet</code> of <code>{@link LoggingOperations}</code> to set.
      */
     public void setLogOperationTypes(final EnumSet<LoggingOperations> logOperationTypes) {
         this.logOperationTypes = logOperationTypes;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/OperationContext.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/OperationContext.java
@@ -186,7 +186,7 @@ public final class OperationContext {
     /**
      * Gets the client side trace ID.
      * 
-     * @return A <code>String</cod> which represents the client request ID.
+     * @return A <code>String</code> which represents the client request ID.
      */
     public String getClientRequestID() {
         return this.clientRequestID;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/RetryInfo.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/RetryInfo.java
@@ -45,7 +45,7 @@ public class RetryInfo {
     }
 
     /**
-     * Initializes a new instance of the {@link "RetryInfo"} class.
+     * Initializes a new instance of the {@link RetryInfo} class.
      * 
      * @param retryContext
      *            The {@link RetryContext} object that was passed in to the retry policy.
@@ -114,7 +114,7 @@ public class RetryInfo {
     }
 
     /**
-     * Returns a string that represents the current {@link "RetryInfo"} instance.
+     * Returns a string that represents the current {@link RetryInfo} instance.
      * 
      * @return A <code>String</code> which represents the current <code>RetryInfo</code> instance.
      */

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/SharedAccessPolicyHandler.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/SharedAccessPolicyHandler.java
@@ -58,8 +58,6 @@ public class SharedAccessPolicyHandler<T extends SharedAccessPolicy> extends Def
      * @return the HashMap of SharedAccessPolicies from the response
      * @throws SAXException
      * @throws ParserConfigurationException
-     * @throws ParseException
-     *             if a date is incorrectly encoded in the stream
      * @throws IOException
      */
     public static <T extends SharedAccessPolicy> HashMap<String, T> getAccessIdentifiers(final InputStream stream,

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/analytics/CloudAnalyticsClient.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/analytics/CloudAnalyticsClient.java
@@ -385,9 +385,7 @@ public class CloudAnalyticsClient {
      * @param logBlobs
      *            An {@link Iterable} of blobs to parse LogRecords from.
      * @return
-     *         An enumerable collection of objects that implement {@link LogRecords} and are retrieved lazily.
-     * @throws StorageException
-     * @throws URISyntaxException
+     *         An enumerable collection of objects that implement {@link LogRecord} and are retrieved lazily.
      */
     public static Iterable<LogRecord> parseLogBlobs(Iterable<ListBlobItem> logBlobs) {
         Utility.assertNotNull("logBlobs", logBlobs);
@@ -398,12 +396,10 @@ public class CloudAnalyticsClient {
     /**
      * Returns an enumerable collection of log records, retrieved lazily.
      * 
-     * @param logBlobs
-     *            An {@link Iterable} of blobs to parse LogRecords from.
+     * @param logBlob
+     *            A single blob to parse LogRecords from.
      * @return
-     *         An enumerable collection of objects that implement {@link LogRecords} and are retrieved lazily.
-     * @throws StorageException
-     * @throws URISyntaxException
+     *         An enumerable collection of objects that implement {@link LogRecord} and are retrieved lazily.
      */
     public static Iterable<LogRecord> parseLogBlob(ListBlobItem logBlob) {
         Utility.assertNotNull("logBlob", logBlob);

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobContainerProperties.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobContainerProperties.java
@@ -108,10 +108,10 @@ public final class BlobContainerProperties {
     /**
      * Gets the public access level for the container.
      * This field should only be set using the container's {@link #create(BlobContainerPublicAccessType,
-     * BlobRequestOptions, OperationContext) create} method or
+     * BlobRequestOptions, com.microsoft.azure.storage.OperationContext) create} method or
      * {@link #uploadPermissions(BlobContainerPermissions) uploadPermissions} method.
      * 
-     * @return A <code>{@link BlobContainerPublicAccessLevel}</code> that specifies the level of public access
+     * @return A <code>{@link BlobContainerPublicAccessType}</code> that specifies the level of public access
      * that is allowed on the container.
      */
     public BlobContainerPublicAccessType getPublicAccess() {
@@ -171,7 +171,7 @@ public final class BlobContainerProperties {
     /**
      * Sets the public access level on the container.
      * This should only be set using the container's {@link #create(BlobContainerPublicAccessType,
-     * BlobRequestOptions, OperationContext) create} method or
+     * BlobRequestOptions, com.microsoft.azure.storage.OperationContext) create} method or
      * {@link #uploadPermissions(BlobContainerPermissions) uploadPermissions} method.
      * @param publicAccess
      *            A <code>{@link BlobContainerPublicAccessType}</code> object

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobInputStream.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobInputStream.java
@@ -337,7 +337,7 @@ public final class BlobInputStream extends InputStream {
      * elements <code>b[0]</code> through <code>b[k-1]</code>, leaving elements <code>b[k]</code> through
      * <code>b[b.length-1]</code> unaffected.
      * 
-     * The <code>read(b) method for class {@link InputStream} has the same effect as:
+     * The <code>read(b)</code> method for class {@link InputStream} has the same effect as:
      * 
      * <code>read(b, 0, b.length)</code>
      * 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobProperties.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobProperties.java
@@ -304,7 +304,7 @@ public final class BlobProperties {
     /**
      * Gets a value indicating if the tier of the blob has been inferred.
      *
-     * @return A {@Link java.lang.Boolean} object which represents if the blob tier was inferred.
+     * @return A {@link java.lang.Boolean} object which represents if the blob tier was inferred.
      */
     public Boolean isBlobTierInferred() { return this.isBlobTierInferredTier; }
 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudAppendBlob.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudAppendBlob.java
@@ -357,7 +357,7 @@ public final class CloudAppendBlob extends CloudBlob {
      *            An {@link OperationContext} object which represents the context for the current operation. This object
      *            is used to track requests to the storage service, and to provide additional runtime information about
      *            the operation.
-     * @return The offset at which the block was appended.</returns>
+     * @return The offset at which the block was appended.
      * @throws IOException
      *             If an I/O exception occurred.
      * @throws StorageException

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlob.java
@@ -1549,7 +1549,7 @@ public abstract class CloudBlob implements ListBlobItem {
      *            A <code>byte</code> array which represents the buffer to which the blob bytes are downloaded.
      * @param bufferOffset
      *            An <code>int</code> which represents the byte offset to use as the starting point for the target.
-     * @returns The total number of bytes read into the buffer.
+     * @return The total number of bytes read into the buffer.
      * 
      * @throws StorageException
      */
@@ -1582,7 +1582,7 @@ public abstract class CloudBlob implements ListBlobItem {
      *            An {@link OperationContext} object that represents the context for the current operation. This object
      *            is used to track requests to the storage service, and to provide additional runtime information about
      *            the operation.
-     * @returns The total number of bytes read into the buffer.
+     * @return The total number of bytes read into the buffer.
      * 
      * @throws StorageException
      *             If a storage service error occurred.

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlobClient.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/CloudBlobClient.java
@@ -136,7 +136,7 @@ public final class CloudBlobClient extends ServiceClient {
     /**
      * Returns the value for the default delimiter used for cloud blob directories. The default is '/'.
      * 
-     * @return A <code>String<code> which represents the value for the default delimiter.
+     * @return A <code>String</code> which represents the value for the default delimiter.
      */
     public String getDirectoryDelimiter() {
         return this.directoryDelimiter;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/SubStream.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/SubStream.java
@@ -60,7 +60,6 @@ public class SubStream extends InputStream {
      * @param streamLength The length of the substream.
      * @param lock         An intrinsic lock to ensure thread-safe, concurrent operations
      *                     on substream instances wrapping the same InputStream.
-     * @throws Exception
      */
     public SubStream(InputStream source, long startIndex, long streamLength, Object lock)  {
         if (startIndex < 0 || streamLength < 1) {

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/file/CloudFileDirectory.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/file/CloudFileDirectory.java
@@ -764,11 +764,6 @@ public final class CloudFileDirectory implements ListFileItem {
      * 
      * @return An enumerable collection of {@link ListFileItem} objects that represent the file and directory items in
      *         this directory.
-     * 
-     * @throws StorageException
-     *             If a storage service error occurred.
-     * @throws URISyntaxException
-     *             If the resource URI is invalid.
      */
     @DoesServiceRequest
     public Iterable<ListFileItem> listFilesAndDirectories(FileRequestOptions options, OperationContext opContext) {
@@ -791,11 +786,6 @@ public final class CloudFileDirectory implements ListFileItem {
      * 
      * @return An enumerable collection of {@link ListFileItem} objects that represent the file and directory items in
      *         this directory.
-     * 
-     * @throws StorageException
-     *             If a storage service error occurred.
-     * @throws URISyntaxException
-     *             If the resource URI is invalid.
      */
     @DoesServiceRequest
     public Iterable<ListFileItem> listFilesAndDirectories(

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/file/CloudFileShare.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/file/CloudFileShare.java
@@ -155,9 +155,7 @@ public final class CloudFileShare {
      *            A <code>java.net.URI</code> object that represents the absolute URI of the share.
      * @param credentials
      *            A {@link StorageCredentials} object used to authenticate access.
-     * @param snapshotID
-     *            A <code>String</code> that represents the snapshot version, if applicable.
-     * 
+     *
      * @throws StorageException
      *             If a storage service error occurred.
      */
@@ -172,8 +170,6 @@ public final class CloudFileShare {
      *            A {@link StorageUri} object which represents the absolute StorageUri of the share.
      * @param credentials
      *            A {@link StorageCredentials} object used to authenticate access.
-     * @param snapshotID
-     *            A <code>String</code> that represents the snapshot version, if applicable.
      * @throws StorageException
      *             If a storage service error occurred.
      */
@@ -1511,7 +1507,7 @@ public final class CloudFileShare {
      *
      * @return <code>true</code> if the share is a snapshot, otherwise <code>false</code>.
      *
-     * @see DeleteSnapshotsOption
+     * @see com.microsoft.azure.storage.blob.DeleteSnapshotsOption
      */
     public final boolean isSnapshot() {
         return this.snapshotID != null;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/file/FileInputStream.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/file/FileInputStream.java
@@ -329,7 +329,7 @@ public class FileInputStream extends InputStream {
      * bytes actually read; these bytes will be stored in elements <code>b[0]</code> through <code>b[k-1]</code>,
      * leaving elements <code>b[k]</code> through <code>b[b.length-1]</code> unaffected.
      * 
-     * The <code>read(b) method for class {@link InputStream} has the same effect as:
+     * The <code>read(b)</code> method for class {@link InputStream} has the same effect as:
      * 
      * <code>read(b, 0, b.length)</code>
      * 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/queue/QueueEncryptionPolicy.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/queue/QueueEncryptionPolicy.java
@@ -83,7 +83,7 @@ public final class QueueEncryptionPolicy {
     /**
      * Gets the key resolver used to select the correct key for decrypting existing queue messages.
      * 
-     * @return A resolver that returns an {@link SymmetricKey} given a keyId.
+     * @return A resolver that returns an {@link IKey} given a keyId.
      */
     public IKeyResolver getKeyResolver() {
         return this.keyResolver;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/CloudTableClient.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/CloudTableClient.java
@@ -36,6 +36,8 @@ import com.microsoft.azure.storage.StorageCredentialsAnonymous;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.StorageExtendedErrorInformation;
 import com.microsoft.azure.storage.StorageUri;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.BlobRequestOptions;
 import com.microsoft.azure.storage.core.ExecutionEngine;
 import com.microsoft.azure.storage.core.LazySegmentedIterable;
 import com.microsoft.azure.storage.core.SR;
@@ -53,7 +55,7 @@ import com.microsoft.azure.storage.core.Utility;
  * <p>
  * A Table service endpoint is the base URI for Table service resources, including the DNS name of the storage account:
  * <br>
- * <code>&nbsp&nbsp&nbsp&nbsphttp://<em>myaccount</em>.table.core.windows.net</code><br>
+ * <code>&nbsp;&nbsp;&nbsp;&nbsp;http://<em>myaccount</em>.table.core.windows.net</code><br>
  * For more information, see the MSDN topic <a
  * href="http://msdn.microsoft.com/en-us/library/azure/dd179360.aspx">Addressing Table Service Resources</a>.
  * <p>

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/EdmType.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/EdmType.java
@@ -35,7 +35,7 @@ import com.microsoft.azure.storage.core.SR;
  * <a href="http://www.odata.org/developers/protocols/overview">OData Protocol Overview</a>.
  * <p>
  * The Abstract Type System used to define the primitive types supported by OData is defined in detail in <a
- * href="http://msdn.microsoft.com/en-us/library/dd541474.aspx">[MC-CSDL] (section 2.2.1).
+ * href="http://msdn.microsoft.com/en-us/library/dd541474.aspx">[MC-CSDL] (section 2.2.1)</a>.
  */
 public enum EdmType {
     /**

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/Encrypt.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/Encrypt.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * annotation to specify whether to encrypt the data stored by a setter method or decrypt the data retrieved by a getter
  * method in a class implementing {@link TableEntity}.
  * 
- * @see {@link Ignore}
+ * @see Ignore
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/EntityProperty.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/EntityProperty.java
@@ -393,7 +393,7 @@ public final class EntityProperty {
      * Gets the class type of the {@link EntityProperty}.
      * 
      * @return
-     *         The <code>Class<?></code> of the {@link EntityProperty}.
+     *         The <code>Class&lt;?&gt;</code> of the {@link EntityProperty}.
      */
     public Class<?> getType() {
         return this.type;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableEncryptionPolicy.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableEncryptionPolicy.java
@@ -88,7 +88,7 @@ public class TableEncryptionPolicy {
     /**
      * Gets the key resolver used to select the correct key for decrypting existing table entities.
      * 
-     * @return A resolver that returns an {@link SymmetricKey} given a keyId.
+     * @return A resolver that returns an {@link IKey} given a keyId.
      */
     public IKeyResolver getKeyResolver() {
         return this.keyResolver;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableQuery.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableQuery.java
@@ -43,10 +43,10 @@ import com.microsoft.azure.storage.core.Utility;
  * <p>
  * As an example, you could construct a table query using fluent syntax:
  * <p>
- * <code>TableQuery&ltTableServiceEntity> myQuery = TableQuery.from("Products", DynamicTableEntity.class)<br>
- * &nbsp&nbsp&nbsp&nbsp.where("(PartitionKey eq 'ProductsMNO') and (RowKey ge 'Napkin')")<br>
- * &nbsp&nbsp&nbsp&nbsp.take(25)<br>
- * &nbsp&nbsp&nbsp&nbsp.select(new String[] {"InventoryCount"});</code>
+ * <code>TableQuery&lt;TableServiceEntity&gt; myQuery = TableQuery.from("Products", DynamicTableEntity.class)<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;.where("(PartitionKey eq 'ProductsMNO') and (RowKey ge 'Napkin')")<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;.take(25)<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;.select(new String[] {"InventoryCount"});</code>
  * <p>
  * This example creates a query on the "Products" table for all entities where the PartitionKey value is "ProductsMNO"
  * and the RowKey value is greater than or equal to "Napkin" and requests the first 25 matching entities, selecting only
@@ -597,7 +597,7 @@ public class TableQuery<T extends TableEntity> {
      * constant. The PartitionKey and RowKey property values are <code>String</code> types for comparison purposes. For
      * example, to query all entities with a PartitionKey value of "AccessLogs" on table query <code>myQuery</code>:
      * <p>
-     * <code>&nbsp&nbsp&nbsp&nbspmyQuery.setFilterString("PartitionKey eq 'AccessLogs'");</code>
+     * <code>&nbsp;&nbsp;&nbsp;&nbsp;myQuery.setFilterString("PartitionKey eq 'AccessLogs'");</code>
      * <p>
      * The values that may be used in table queries are explained in more detail in the MSDN topic
      * 
@@ -676,7 +676,7 @@ public class TableQuery<T extends TableEntity> {
      * PartitionKey and RowKey property values are <code>String</code> types for comparison purposes. For example, to
      * query all entities with a PartitionKey value of "AccessLogs" on table query <code>myQuery</code>:
      * <p>
-     * <code>&nbsp&nbsp&nbsp&nbspmyQuery = myQuery.where("PartitionKey eq 'AccessLogs'");</code>
+     * <code>&nbsp;&nbsp;&nbsp;&nbsp;myQuery = myQuery.where("PartitionKey eq 'AccessLogs'");</code>
      * <p>
      * The values that may be used in table queries are explained in more detail in the MSDN topic
      * 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableRequestOptions.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableRequestOptions.java
@@ -27,7 +27,7 @@ import com.microsoft.azure.storage.core.Utility;
 public class TableRequestOptions extends RequestOptions {
 
     /**
-     * The interface whose function is used to get the <see cref="EdmType"/> for an entity property
+     * The interface whose function is used to get the {@link EdmType} for an entity property
      * given the partition key, row, key, and the property name, if the interface is implemented
      */
     public interface PropertyResolver {
@@ -223,7 +223,7 @@ public class TableRequestOptions extends RequestOptions {
     }
 
     /**
-     * Gets the interface that contains a function which is used to get the <see cref="EdmType"/> for an entity property
+     * Gets the interface that contains a function which is used to get the {@link EdmType} for an entity property
      * given the partition key, row, key, and the property name. For more information about the {@link PropertyResolver}
      * defaults, see {@link #setPropertyResolver(PropertyResolver)}.
      * 
@@ -286,7 +286,7 @@ public class TableRequestOptions extends RequestOptions {
     }
 
     /**
-     * Sets the interface that contains a function which is used to get the <see cref="EdmType"/> for an entity property
+     * Sets the interface that contains a function which is used to get the {@link EdmType} for an entity property
      * given the partition key, row, key, and the property name.
      * <p>
      * The default {@link PropertyResolver} is set in the client and is by default null, indicating not to use a
@@ -340,11 +340,11 @@ public class TableRequestOptions extends RequestOptions {
      * required if a {@link TableEncryptionPolicy} is specified.
      * <p>
      * You can change the {@link EncryptionResolver} on this request by setting this property. You can also change the 
-     * value on the {@link TableServiceClient#getDefaultRequestOptions()} object so that all subsequent requests made 
+     * value on the {@link TableServiceClient#getDefaultRequestOptions()} object so that all subsequent requests made
      * via the service client will use that {@link EncryptionResolver}.
      * 
-     * @param propertyResolver
-     *            Specifies the {@link PropertyResolver} to set.
+     * @param encryptionResolver
+     *            Specifies the {@link EncryptionResolver} to set.
      */
     public void setEncryptionResolver(EncryptionResolver encryptionResolver) {
         this.encryptionResolver = encryptionResolver;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableResult.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableResult.java
@@ -50,7 +50,7 @@ public class TableResult {
      * Initializes a {@link TableResult} instance with the specified HTTP status code.
      * 
      * @param httpStatusCode
-     *            An <code>int<code> which represents the HTTP status code for the table operation returned by the server.
+     *            An <code>int</code> which represents the HTTP status code for the table operation returned by the server.
      */
     public TableResult(final int httpStatusCode) {
         this.httpStatusCode = httpStatusCode;
@@ -71,7 +71,7 @@ public class TableResult {
      * Gets the HTTP status code returned by a table operation request.
      * 
      * @return
-     *         An <code>int<code> which represents the HTTP status code for the table operation returned by the server.
+     *         An <code>int</code> which represents the HTTP status code for the table operation returned by the server.
      */
     public int getHttpStatusCode() {
         return this.httpStatusCode;

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableServiceEntity.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableServiceEntity.java
@@ -58,7 +58,7 @@ import com.microsoft.azure.storage.core.SR;
  * <p>
  * The following table shows the supported property data types in Microsoft Azure storage and the corresponding Java
  * types when deserialized.
- * <TABLE BORDER="1" WIDTH="100%" CELLPADDING="3" CELLSPACING="0">
+ * <TABLE BORDER="1" WIDTH="100%" CELLPADDING="3" CELLSPACING="0" summary="Supported property data types in Microsoft Azure storage">
  * <TR BGCOLOR="#EEEEFF" CLASS="TableSubHeadingColor">
  * <th>Storage Type</th>
  * <th>EdmType Value</th>

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableServiceException.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableServiceException.java
@@ -62,7 +62,7 @@ public final class TableServiceException extends StorageException {
      * @param message
      *            A <code>String</code> that represents the error message returned by the table operation.
      * @param statusCode
-     *            An <code>int>/code> which represents the HTTP status code returned by the table operation.
+     *            An <code>int</code> which represents the HTTP status code returned by the table operation.
      * @param extendedErrorInfo
      *            A {@link StorageExtendedErrorInformation} object that represents the extended error information
      *            returned by the table operation.


### PR DESCRIPTION
This is a PR that begins to resolve issues when attempting to generate JavaDoc for this API. It is the low-hanging fruit - but there are still three errors I am unsure how to resolve. They are:

> 
> [ERROR] /Users/jonathan/Code/azure/forks/azure-storage-java/microsoft-azure-storage/src/com/microsoft/azure/storage/table/TableRequestOptions.java:343: error: reference not found
> [ERROR]      * value on the {@link TableServiceClient#getDefaultRequestOptions()} object so that all subsequent requests made
> [ERROR]                            ^
> [ERROR] /Users/jonathan/Code/azure/forks/azure-storage-java/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobContainerProperties.java:110: error: reference not found
> [ERROR]      * This field should only be set using the container's {@link #create(BlobContainerPublicAccessType,
> [ERROR]                                                                   ^
> [ERROR] /Users/jonathan/Code/azure/forks/azure-storage-java/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobContainerProperties.java:112: error: reference not found
> [ERROR]      * {@link #uploadPermissions(BlobContainerPermissions) uploadPermissions} method.


The API has clearly changed without the docs being updated. I am happy to attempt to fix these, but I need pointers. If possible, can you generate javadoc and get a feeling for how these should be fixed, and let me know (unless you want to fix them yourself)?