### PR TITLE
Set fixed length streaming mode for request path in executor.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,8 @@
+XXXX.XX.XX Version X.X.X
+ * Improved performance of blob uploadFromFile APIs to avoid unnecessary buffering.
+ * Improved performance when streaming directly from a FileInputStream to avoid unnecessary buffering.
+ * Switched to using fixed length streaming mode in the HTTP client to avoid unnecessary buffering.
+
 2017.11.01 Version 6.1.0
  * Added support for the last time the tier was modified.
 

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/ExecutionEngine.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/ExecutionEngine.java
@@ -87,6 +87,15 @@ public final class ExecutionEngine {
                 try {
                     if (task.getSendStream() != null) {
                         Logger.info(opContext, LogConstants.UPLOAD);
+
+                        // Always set fixed length streaming mode when we know the length in advance.
+                        // This sets the Content-Length of the request and allows the request payload to
+                        // be streamed from the source. Otherwise, the HTTP layer will buffer the entire
+                        // request and compute the Content-Length itself.
+                        if (task.getLength() >= 0) {
+                            request.setFixedLengthStreamingMode(task.getLength());
+                        }
+
                         final StreamMd5AndLength descriptor = Utility.writeToOutputStream(task.getSendStream(),
                                 request.getOutputStream(), task.getLength(), false /* rewindStream */,
                                 false /* calculate MD5 */, opContext, task.getRequestOptions());


### PR DESCRIPTION
This ensures that requests are not buffered unnecessarily in the HTTP layer.