### PR TITLE
Fix ContinuationType Error Message

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Utility.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/Utility.java
@@ -347,7 +347,7 @@ public final class Utility {
             if (!(continuationToken.getContinuationType() == ResultContinuationType.NONE || continuationToken
                     .getContinuationType() == continuationType)) {
                 final String errorMessage = String.format(Utility.LOCALE_US, SR.UNEXPECTED_CONTINUATION_TYPE,
-                        continuationToken.getContinuationType(), continuationType);
+                        continuationType, continuationToken.getContinuationType());
                 throw new IllegalArgumentException(errorMessage);
             }
         }


### PR DESCRIPTION
_Expected_ and _Found_ ContinuationTypes are mixed up. For example, the following error can be observed:

> The continuation type passed in is unexpected. Please verify that the correct continuation type is passed in. Expected {null}, found {TABLE}.

While {TABLE} should be _Expected_