### PR TITLE
Fix Service SAS null parameters

### DIFF
--- a/src/main/java/com/microsoft/azure/storage/blob/AccountSASSignatureValues.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/AccountSASSignatureValues.java
@@ -106,18 +106,7 @@ public final class AccountSASSignatureValues {
         Utility.assertNotNull("permissions", this.permissions);
 
         // Signature is generated on the un-url-encoded values.
-        String stringToSign = String.join("\n",
-                sharedKeyCredentials.getAccountName(),
-                AccountSASPermission.parse(this.permissions).toString(), // guarantees ordering
-                this.services,
-                resourceTypes,
-                this.startTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.startTime),
-                this.expiryTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.expiryTime),
-                this.ipRange == null ? IPRange.DEFAULT.toString() : this.ipRange.toString(),
-                this.protocol == null ? "" : this.protocol.toString(),
-                this.version,
-                Constants.EMPTY_STRING // Account SAS requires an additional newline character
-        );
+        final String stringToSign = stringToSign(sharedKeyCredentials);
 
         String signature;
         try {
@@ -129,5 +118,20 @@ public final class AccountSASSignatureValues {
         return new SASQueryParameters(this.version, this.services, resourceTypes,
                 this.protocol, this.startTime, this.expiryTime, this.ipRange, null,
                 null, this.permissions, signature);
+    }
+
+    private String stringToSign(final SharedKeyCredentials sharedKeyCredentials) {
+        return String.join("\n",
+                sharedKeyCredentials.getAccountName(),
+                AccountSASPermission.parse(this.permissions).toString(), // guarantees ordering
+                this.services,
+                resourceTypes,
+                this.startTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.startTime),
+                this.expiryTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.expiryTime),
+                this.ipRange == null ? IPRange.DEFAULT.toString() : this.ipRange.toString(),
+                this.protocol == null ? "" : this.protocol.toString(),
+                this.version,
+                Constants.EMPTY_STRING // Account SAS requires an additional newline character
+        );
     }
 }

--- a/src/main/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValues.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValues.java
@@ -148,15 +148,15 @@ public final class ServiceSASSignatureValues {
                  this.startTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.startTime),
                  this.expiryTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.expiryTime),
                  getCanonicalName(sharedKeyCredentials.getAccountName()),
-                 this.identifier,
+                 this.identifier == null ? "" : this.identifier,
                  this.ipRange == null ? IPRange.DEFAULT.toString() : this.ipRange.toString(),
                  this.protocol == null ? "" : protocol.toString(),
                  this.version,
-                 this.cacheControl,
-                 this.contentDisposition,
-                 this.contentEncoding,
-                 this.contentLanguage,
-                 this.contentType
+                 this.cacheControl == null ? "" : this.cacheControl,
+                 this.contentDisposition == null ? "" : this.contentDisposition,
+                 this.contentEncoding == null ? "" : this.contentEncoding,
+                 this.contentLanguage == null ? "" : this.contentLanguage,
+                 this.contentType == null ? "" : this.contentType
          );
 
         String signature = null;

--- a/src/main/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValues.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValues.java
@@ -143,21 +143,7 @@ public final class ServiceSASSignatureValues {
         }
 
         // Signature is generated on the un-url-encoded values.
-         String stringToSign = String.join("\n",
-                 verifiedPermissions,
-                 this.startTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.startTime),
-                 this.expiryTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.expiryTime),
-                 getCanonicalName(sharedKeyCredentials.getAccountName()),
-                 this.identifier == null ? "" : this.identifier,
-                 this.ipRange == null ? IPRange.DEFAULT.toString() : this.ipRange.toString(),
-                 this.protocol == null ? "" : protocol.toString(),
-                 this.version,
-                 this.cacheControl == null ? "" : this.cacheControl,
-                 this.contentDisposition == null ? "" : this.contentDisposition,
-                 this.contentEncoding == null ? "" : this.contentEncoding,
-                 this.contentLanguage == null ? "" : this.contentLanguage,
-                 this.contentType == null ? "" : this.contentType
-         );
+        final String stringToSign = stringToSign(verifiedPermissions, sharedKeyCredentials);
 
         String signature = null;
         try {
@@ -182,5 +168,24 @@ public final class ServiceSASSignatureValues {
         }
 
         return canonicalName.toString();
+    }
+
+    private String stringToSign(final String verifiedPermissions,
+                                final SharedKeyCredentials sharedKeyCredentials) {
+        return String.join("\n",
+                verifiedPermissions,
+                this.startTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.startTime),
+                this.expiryTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.expiryTime),
+                getCanonicalName(sharedKeyCredentials.getAccountName()),
+                this.identifier == null ? "" : this.identifier,
+                this.ipRange == null ? IPRange.DEFAULT.toString() : this.ipRange.toString(),
+                this.protocol == null ? "" : protocol.toString(),
+                this.version,
+                this.cacheControl == null ? "" : this.cacheControl,
+                this.contentDisposition == null ? "" : this.contentDisposition,
+                this.contentEncoding == null ? "" : this.contentEncoding,
+                this.contentLanguage == null ? "" : this.contentLanguage,
+                this.contentType == null ? "" : this.contentType
+        );
     }
 }

--- a/src/test/java/com/microsoft/azure/storage/HelperTest.groovy
+++ b/src/test/java/com/microsoft/azure/storage/HelperTest.groovy
@@ -15,11 +15,20 @@
 
 package com.microsoft.azure.storage
 
+import com.microsoft.azure.storage.blob.AccountSASResourceType
+import com.microsoft.azure.storage.blob.AccountSASService
+import com.microsoft.azure.storage.blob.AccountSASSignatureValues
+import com.microsoft.azure.storage.blob.BlobSASPermission
+import com.microsoft.azure.storage.blob.ContainerSASPermission
+import com.microsoft.azure.storage.blob.IPRange
 import com.microsoft.azure.storage.blob.RequestRetryFactory
 import com.microsoft.azure.storage.blob.RequestRetryOptions
 import com.microsoft.azure.storage.blob.RequestRetryTestFactory
 import com.microsoft.azure.storage.blob.RetryPolicyType
+import com.microsoft.azure.storage.blob.SASProtocol
+import com.microsoft.azure.storage.blob.ServiceSASSignatureValues
 import com.microsoft.azure.storage.blob.StorageException
+import com.microsoft.azure.storage.blob.Utility
 import com.microsoft.azure.storage.blob.models.StorageErrorCode
 import com.microsoft.azure.storage.blob.models.StorageErrorException
 import com.microsoft.rest.v2.http.HttpHeaders
@@ -29,6 +38,10 @@ import com.microsoft.rest.v2.http.HttpRequest
 import com.microsoft.rest.v2.http.HttpResponse
 import io.reactivex.Flowable
 import spock.lang.Unroll
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 class HelperTest extends APISpec {
 
@@ -43,4 +56,48 @@ class HelperTest extends APISpec {
         e.message().contains("Value for one of the query parameters specified in the request URI is invalid.")
         e.getMessage().contains("<?xml") // Ensure that the details in the payload are printable
     }
+
+    def "serviceSasSignatures"() {
+        when:
+        def v = new ServiceSASSignatureValues()
+        v.blobName = "foo"
+        v.containerName = "bar"
+        v.expiryTime = OffsetDateTime.of(2017, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        v.protocol = SASProtocol.HTTPS_ONLY
+        def p = new BlobSASPermission()
+        p.read = true
+        v.permissions = p.toString();
+        def expectedCanonicalName = "/blob/${primaryCreds.accountName}/${v.containerName}/${v.blobName}"
+        def expectedStringToSign = "${v.permissions}\n\n${Utility.ISO8601UTCDateFormatter.format(v.expiryTime)}\n${expectedCanonicalName}\n\n${IPRange.DEFAULT.toString()}\n${v.protocol}\n${v.version}\n\n\n\n\n"
+
+        def token = v.generateSASQueryParameters(primaryCreds)
+
+        then:
+        token.signature == primaryCreds.computeHmac256(expectedStringToSign)
+    }
+
+    def "accountSasSignatures"() {
+        when:
+        def v = new AccountSASSignatureValues()
+        v.expiryTime = OffsetDateTime.of(2017, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        v.protocol = SASProtocol.HTTPS_ONLY
+        def p = new ContainerSASPermission()
+        p.read = true
+        v.permissions = p.toString()
+        def s = new AccountSASService()
+        s.blob = true
+        v.services = s.toString()
+        def t = new AccountSASResourceType()
+        t.container = true
+        t.object = true
+        v.resourceTypes = t.toString()
+        def expectedStringToSign = "${primaryCreds.accountName}\n${p.toString()}\n${v.services}\n${v.resourceTypes}\n\n${Utility.ISO8601UTCDateFormatter.format(v.expiryTime)}\n${IPRange.DEFAULT.toString()}\n${SASProtocol.HTTPS_ONLY}\n${v.version}\n"
+        def token = v.generateSASQueryParameters(primaryCreds)
+
+        then:
+        token.signature == primaryCreds.computeHmac256(expectedStringToSign)
+
+    }
+
+
 }

--- a/src/test/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValuesTest.groovy
+++ b/src/test/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValuesTest.groovy
@@ -1,7 +1,0 @@
-package com.microsoft.azure.storage.blob
-
-import com.microsoft.azure.storage.APISpec
-
-class ServiceSASSignatureValuesTest extends APISpec {
-    
-}

--- a/src/test/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValuesTest.groovy
+++ b/src/test/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValuesTest.groovy
@@ -1,0 +1,7 @@
+package com.microsoft.azure.storage.blob
+
+import com.microsoft.azure.storage.APISpec
+
+class ServiceSASSignatureValuesTest extends APISpec {
+    
+}


### PR DESCRIPTION
Resolves #354 by replacing null fields in `ServiceSASSignatureValues` with the empty string in when forming the string to sign. `AccountSASSignatureValues` asserts that fields without null checks are not null early and so doesn't have the same issue. Added tests to both classes.