### PR TITLE
Removed DEFAULT and NONE static variables, Created empty constructors…

### DIFF
--- a/BreakingChanges.txt
+++ b/BreakingChanges.txt
@@ -1,6 +1,7 @@
 ﻿XXXX.XX.XX Version XX.X.X
 * HTTPGetterInfo was made an internal type as it is an internal implementation detail.
 * DownloadResponse constructor was made internal as there is no need for customers to construct their own responses; all HTTP responses should be generated internally.
+* Removed DEFAULT and NONE static variables. Empty constructors should be used instead. DEFAULT static values were error prone and unsafe to use because although the field was final, the objects were mutable, so it was possible the value could be changed accidentally and alter the behavior of the program.
 
 2018.08.11 Version 10.1.0
 * Interfaces for helper types updated to be more consistent throughout the library. All types, with the exception of the options for pipeline factories, use a fluent pattern.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@ XXXX.XX.XX Version XX.X.X
 * Added CopyFromURL, which will do a synchronous server-side copy, meaning the service will not return an HTTP response until it has completed the copy.
 * HTTPGetterInfo was made an internal type as it is an internal implementation detail.
 * DownloadResponse constructor was made internal as there is no need for customers to construct their own responses; all HTTP responses should be generated internally.
+* Removed DEFAULT and NONE static variables. Empty constructors should be used instead. DEFAULT static values were error prone and unsafe to use because although the field was final, the objects were mutable, so it was possible the value could be changed accidentally and alter the behavior of the program.
 
 2018.09.11 Version 10.1.0
 * Interfaces for helper types updated to be more consistent throughout the library. All types, with the exception of the options for pipeline factories, use a fluent pattern.

--- a/src/main/java/com/microsoft/azure/storage/blob/AccountSASSignatureValues.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/AccountSASSignatureValues.java
@@ -228,7 +228,7 @@ public final class AccountSASSignatureValues {
                 resourceTypes,
                 this.startTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.startTime),
                 Utility.ISO8601UTCDateFormatter.format(this.expiryTime),
-                this.ipRange == null ? IPRange.DEFAULT.toString() : this.ipRange.toString(),
+                this.ipRange == null ? (new IPRange()).toString() : this.ipRange.toString(),
                 this.protocol == null ? "" : this.protocol.toString(),
                 this.version,
                 Constants.EMPTY_STRING // Account SAS requires an additional newline character

--- a/src/main/java/com/microsoft/azure/storage/blob/AppendBlobAccessConditions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/AppendBlobAccessConditions.java
@@ -28,12 +28,6 @@ import com.microsoft.azure.storage.blob.models.ModifiedAccessConditions;
  */
 public final class AppendBlobAccessConditions {
 
-    /**
-     * An object representing no access conditions.
-     */
-    public static final AppendBlobAccessConditions NONE =
-            new AppendBlobAccessConditions();
-
     private AppendPositionAccessConditions appendPositionAccessConditions;
 
     private ModifiedAccessConditions modifiedAccessConditions;

--- a/src/main/java/com/microsoft/azure/storage/blob/AppendBlobURL.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/AppendBlobURL.java
@@ -132,8 +132,8 @@ public final class AppendBlobURL extends BlobURL {
      */
     public Single<AppendBlobCreateResponse> create(BlobHTTPHeaders headers, Metadata metadata,
             BlobAccessConditions accessConditions, Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        metadata = metadata == null ? new Metadata() : metadata;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedAppendBlobs().createWithRestResponseAsync(context,
@@ -195,10 +195,10 @@ public final class AppendBlobURL extends BlobURL {
      */
     public Single<AppendBlobAppendBlockResponse> appendBlock(Flowable<ByteBuffer> data, long length,
             AppendBlobAccessConditions appendBlobAccessConditions, Context context) {
-        appendBlobAccessConditions = appendBlobAccessConditions == null ? AppendBlobAccessConditions.NONE :
+        appendBlobAccessConditions = appendBlobAccessConditions == null ? new AppendBlobAccessConditions() :
                 appendBlobAccessConditions;
         appendBlobAccessConditions = appendBlobAccessConditions == null
-                ? AppendBlobAccessConditions.NONE : appendBlobAccessConditions;
+                ? new AppendBlobAccessConditions() : appendBlobAccessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedAppendBlobs().appendBlockWithRestResponseAsync(

--- a/src/main/java/com/microsoft/azure/storage/blob/BlobAccessConditions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/BlobAccessConditions.java
@@ -25,9 +25,6 @@ import com.microsoft.azure.storage.blob.models.ModifiedAccessConditions;
  */
 public final class BlobAccessConditions {
 
-    public static final BlobAccessConditions NONE =
-            new BlobAccessConditions();
-
     private ModifiedAccessConditions modifiedAccessConditions;
 
     private LeaseAccessConditions leaseAccessConditions;

--- a/src/main/java/com/microsoft/azure/storage/blob/BlobListingDetails.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/BlobListingDetails.java
@@ -26,11 +26,6 @@ import java.util.ArrayList;
  */
 public final class BlobListingDetails {
 
-    /**
-     * An object representing no listing details.
-     */
-    public static final BlobListingDetails NONE = new BlobListingDetails();
-
     private boolean copy;
 
     private boolean metadata;

--- a/src/main/java/com/microsoft/azure/storage/blob/BlobRange.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/BlobRange.java
@@ -23,11 +23,6 @@ import java.util.Locale;
  */
 public final class BlobRange {
 
-    /**
-     * An object which reflects the service's default range, which is the whole blob.
-     */
-    public static final BlobRange DEFAULT = new BlobRange();
-
     private long offset;
 
     private Long count;

--- a/src/main/java/com/microsoft/azure/storage/blob/BlobURL.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/BlobURL.java
@@ -173,10 +173,10 @@ public class BlobURL extends StorageURL {
     public Single<BlobStartCopyFromURLResponse> startCopyFromURL(URL sourceURL, Metadata metadata,
             ModifiedAccessConditions sourceModifiedAccessConditions, BlobAccessConditions destAccessConditions,
             Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
+        metadata = metadata == null ? new Metadata() : metadata;
         sourceModifiedAccessConditions = sourceModifiedAccessConditions == null ?
                 new ModifiedAccessConditions() : sourceModifiedAccessConditions;
-        destAccessConditions = destAccessConditions == null ? BlobAccessConditions.NONE : destAccessConditions;
+        destAccessConditions = destAccessConditions == null ? new BlobAccessConditions() : destAccessConditions;
         context = context == null ? Context.NONE : context;
 
         // We want to hide the SourceAccessConditions type from the user for consistency's sake, so we convert here.
@@ -288,10 +288,10 @@ public class BlobURL extends StorageURL {
     public Single<BlobCopyFromURLResponse> syncCopyFromURL(URL copySource, Metadata metadata,
             ModifiedAccessConditions sourceModifiedAccessConditions, BlobAccessConditions destAccessConditions,
             Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
+        metadata = metadata == null ? new Metadata() : metadata;
         sourceModifiedAccessConditions = sourceModifiedAccessConditions == null ?
                 new ModifiedAccessConditions() : sourceModifiedAccessConditions;
-        destAccessConditions = destAccessConditions == null ? BlobAccessConditions.NONE : destAccessConditions;
+        destAccessConditions = destAccessConditions == null ? new BlobAccessConditions() : destAccessConditions;
         context = context == null ? Context.NONE : context;
 
         // We want to hide the SourceAccessConditions type from the user for consistency's sake, so we convert here.
@@ -371,8 +371,8 @@ public class BlobURL extends StorageURL {
     public Single<DownloadResponse> download(BlobRange range, BlobAccessConditions accessConditions,
             boolean rangeGetContentMD5, Context context) {
         Boolean getMD5 = rangeGetContentMD5 ? rangeGetContentMD5 : null;
-        range = range == null ? BlobRange.DEFAULT : range;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        range = range == null ? new BlobRange() : range;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         HTTPGetterInfo info = new HTTPGetterInfo()
                 .withCount(range.offset())
                 .withCount(range.count())
@@ -435,7 +435,7 @@ public class BlobURL extends StorageURL {
      */
     public Single<BlobDeleteResponse> delete(DeleteSnapshotsOptionType deleteBlobSnapshotOptions,
             BlobAccessConditions accessConditions, Context context) {
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedBlobs().deleteWithRestResponseAsync(
@@ -476,7 +476,7 @@ public class BlobURL extends StorageURL {
      * For more samples, please see the [Samples file](%https://github.com/Azure/azure-storage-java/blob/master/src/test/java/com/microsoft/azure/storage/Samples.java)
      */
     public Single<BlobGetPropertiesResponse> getProperties(BlobAccessConditions accessConditions, Context context) {
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedBlobs().getPropertiesWithRestResponseAsync(
@@ -523,7 +523,7 @@ public class BlobURL extends StorageURL {
      */
     public Single<BlobSetHTTPHeadersResponse> setHTTPHeaders(BlobHTTPHeaders headers,
             BlobAccessConditions accessConditions, Context context) {
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedBlobs().setHTTPHeadersWithRestResponseAsync(
@@ -569,8 +569,8 @@ public class BlobURL extends StorageURL {
      */
     public Single<BlobSetMetadataResponse> setMetadata(Metadata metadata, BlobAccessConditions accessConditions,
             Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        metadata = metadata == null ? new Metadata() : metadata;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedBlobs().setMetadataWithRestResponseAsync(
@@ -613,8 +613,8 @@ public class BlobURL extends StorageURL {
      */
     public Single<BlobCreateSnapshotResponse> createSnapshot(Metadata metadata, BlobAccessConditions accessConditions,
             Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        metadata = metadata == null ? new Metadata() : metadata;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedBlobs().createSnapshotWithRestResponseAsync(

--- a/src/main/java/com/microsoft/azure/storage/blob/BlockBlobURL.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/BlockBlobURL.java
@@ -166,8 +166,8 @@ public final class BlockBlobURL extends BlobURL {
      */
     public Single<BlockBlobUploadResponse> upload(Flowable<ByteBuffer> data, long length, BlobHTTPHeaders headers,
             Metadata metadata, BlobAccessConditions accessConditions, Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        metadata = metadata == null ? new Metadata() : metadata;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedBlockBlobs().uploadWithRestResponseAsync(context,
@@ -307,7 +307,7 @@ public final class BlockBlobURL extends BlobURL {
     public Single<BlockBlobStageBlockFromURLResponse> stageBlockFromURL(String base64BlockID, URL sourceURL,
             BlobRange sourceRange, byte[] sourceContentMD5, LeaseAccessConditions leaseAccessConditions,
             Context context) {
-        sourceRange = sourceRange == null ? BlobRange.DEFAULT : sourceRange;
+        sourceRange = sourceRange == null ? new BlobRange() : sourceRange;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(
@@ -423,8 +423,8 @@ public final class BlockBlobURL extends BlobURL {
      */
     public Single<BlockBlobCommitBlockListResponse> commitBlockList(List<String> base64BlockIDs,
             BlobHTTPHeaders headers, Metadata metadata, BlobAccessConditions accessConditions, Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        metadata = metadata == null ? new Metadata() : metadata;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedBlockBlobs().commitBlockListWithRestResponseAsync(

--- a/src/main/java/com/microsoft/azure/storage/blob/ContainerAccessConditions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ContainerAccessConditions.java
@@ -25,11 +25,6 @@ import com.microsoft.azure.storage.blob.models.ModifiedAccessConditions;
  */
 public final class ContainerAccessConditions {
 
-    /**
-     * An object representing no access conditions.
-     */
-    public static final ContainerAccessConditions NONE = new ContainerAccessConditions();
-
     private ModifiedAccessConditions modifiedAccessConditions;
 
     private LeaseAccessConditions leaseAccessConditions;

--- a/src/main/java/com/microsoft/azure/storage/blob/ContainerListingDetails.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ContainerListingDetails.java
@@ -24,11 +24,6 @@ import com.microsoft.azure.storage.blob.models.ListContainersIncludeType;
  */
 public final class ContainerListingDetails {
 
-    /**
-     * An object indicating that no extra details should be returned.
-     */
-    public static final ContainerListingDetails NONE = new ContainerListingDetails();
-
     private boolean metadata;
 
     public ContainerListingDetails() {

--- a/src/main/java/com/microsoft/azure/storage/blob/ContainerURL.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ContainerURL.java
@@ -202,7 +202,7 @@ public final class ContainerURL extends StorageURL {
      * For more samples, please see the [Samples file](%https://github.com/Azure/azure-storage-java/blob/master/src/test/java/com/microsoft/azure/storage/Samples.java)
      */
     public Single<ContainerCreateResponse> create(Metadata metadata, PublicAccessType accessType, Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
+        metadata = metadata == null ? new Metadata() : metadata;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedContainers().createWithRestResponseAsync(
@@ -246,7 +246,7 @@ public final class ContainerURL extends StorageURL {
      * For more samples, please see the [Samples file](%https://github.com/Azure/azure-storage-java/blob/master/src/test/java/com/microsoft/azure/storage/Samples.java)
      */
     public Single<ContainerDeleteResponse> delete(ContainerAccessConditions accessConditions, Context context) {
-        accessConditions = accessConditions == null ? ContainerAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new ContainerAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         if (!validateNoEtag(accessConditions.modifiedAccessConditions())) {
@@ -342,8 +342,8 @@ public final class ContainerURL extends StorageURL {
      */
     public Single<ContainerSetMetadataResponse> setMetadata(Metadata metadata,
             ContainerAccessConditions accessConditions, Context context) {
-        metadata = metadata == null ? Metadata.NONE : metadata;
-        accessConditions = accessConditions == null ? ContainerAccessConditions.NONE : accessConditions;
+        metadata = metadata == null ? new Metadata() : metadata;
+        accessConditions = accessConditions == null ? new ContainerAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
         if (!validateNoEtag(accessConditions.modifiedAccessConditions()) ||
                 accessConditions.modifiedAccessConditions().ifUnmodifiedSince() != null) {
@@ -457,7 +457,7 @@ public final class ContainerURL extends StorageURL {
      */
     public Single<ContainerSetAccessPolicyResponse> setAccessPolicy(PublicAccessType accessType,
             List<SignedIdentifier> identifiers, ContainerAccessConditions accessConditions, Context context) {
-        accessConditions = accessConditions == null ? ContainerAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new ContainerAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         if (!validateNoEtag(accessConditions.modifiedAccessConditions())) {
@@ -839,7 +839,7 @@ public final class ContainerURL extends StorageURL {
      */
     public Single<ContainerListBlobFlatSegmentResponse> listBlobsFlatSegment(String marker, ListBlobsOptions options,
             Context context) {
-        options = options == null ? ListBlobsOptions.DEFAULT : options;
+        options = options == null ? new ListBlobsOptions() : options;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedContainers()
@@ -911,7 +911,7 @@ public final class ContainerURL extends StorageURL {
      */
     public Single<ContainerListBlobHierarchySegmentResponse> listBlobsHierarchySegment(String marker, String delimiter,
             ListBlobsOptions options, Context context) {
-        options = options == null ? ListBlobsOptions.DEFAULT : options;
+        options = options == null ? new ListBlobsOptions() : options;
         if (options.details().snapshots()) {
             throw new UnsupportedOperationException("Including snapshots in a hierarchical listing is not supported.");
         }

--- a/src/main/java/com/microsoft/azure/storage/blob/IPRange.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/IPRange.java
@@ -23,8 +23,6 @@ import java.net.Inet4Address;
  */
 public final class IPRange {
 
-    public static final IPRange DEFAULT = new IPRange();
-
     private String ipMin;
 
     private String ipMax;

--- a/src/main/java/com/microsoft/azure/storage/blob/ListBlobsOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ListBlobsOptions.java
@@ -20,12 +20,6 @@ package com.microsoft.azure.storage.blob;
  */
 public final class ListBlobsOptions {
 
-    /**
-     * An object representing the default options: no details, prefix, or delimiter. Uses the server default for
-     * maxResults.
-     */
-    public static final ListBlobsOptions DEFAULT = new ListBlobsOptions();
-
     private BlobListingDetails details;
 
     private String prefix;
@@ -33,7 +27,7 @@ public final class ListBlobsOptions {
     private Integer maxResults;
 
     public ListBlobsOptions() {
-        this.details = BlobListingDetails.NONE;
+        this.details = new BlobListingDetails();
     }
 
     /**

--- a/src/main/java/com/microsoft/azure/storage/blob/ListContainersOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ListContainersOptions.java
@@ -21,12 +21,6 @@ package com.microsoft.azure.storage.blob;
  */
 public final class ListContainersOptions {
 
-    /**
-     * An object representing the default options: no details or prefix and using the service's default for maxResults.
-     */
-    public static final ListContainersOptions DEFAULT =
-            new ListContainersOptions();
-
     private ContainerListingDetails details;
 
     private String prefix;
@@ -34,7 +28,7 @@ public final class ListContainersOptions {
     private Integer maxResults;
 
     public ListContainersOptions() {
-        this.details = ContainerListingDetails.NONE;
+        this.details = new ContainerListingDetails();
     }
 
     /**

--- a/src/main/java/com/microsoft/azure/storage/blob/LoggingFactory.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/LoggingFactory.java
@@ -44,7 +44,7 @@ public final class LoggingFactory implements RequestPolicyFactory {
      *         The configurations for this factory. Null will indicate use of the default options.
      */
     public LoggingFactory(LoggingOptions loggingOptions) {
-        this.loggingOptions = loggingOptions == null ? LoggingOptions.DEFAULT : loggingOptions;
+        this.loggingOptions = loggingOptions == null ? new LoggingOptions() : loggingOptions;
     }
 
     @Override

--- a/src/main/java/com/microsoft/azure/storage/blob/LoggingOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/LoggingOptions.java
@@ -22,9 +22,13 @@ public final class LoggingOptions {
     /**
      * Default logging options. {@code MinDurationToLogSlowRequestsInMs} is set to 3000;
      */
-    public static final LoggingOptions DEFAULT = new LoggingOptions(3000);
+    public static final long defaultMinDurationToLogSlowRequests = 3000;
 
     private final long minDurationToLogSlowRequestsInMs;
+
+    public LoggingOptions() {
+        this(defaultMinDurationToLogSlowRequests);
+    }
 
     /**
      * Creates a new {@link LoggingOptions} object.

--- a/src/main/java/com/microsoft/azure/storage/blob/Metadata.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/Metadata.java
@@ -23,7 +23,6 @@ import java.util.Map;
  * URL type. Null may be passed to set no metadata.
  */
 public final class Metadata extends HashMap<String, String> {
-    public static final Metadata NONE = new Metadata();
 
     public Metadata() {
         super();

--- a/src/main/java/com/microsoft/azure/storage/blob/PageBlobAccessConditions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/PageBlobAccessConditions.java
@@ -27,11 +27,6 @@ import com.microsoft.azure.storage.blob.models.SequenceNumberAccessConditions;
  */
 public final class PageBlobAccessConditions {
 
-    /**
-     * An object representing no access conditions.
-     */
-    public static final PageBlobAccessConditions NONE = new PageBlobAccessConditions();
-
     private SequenceNumberAccessConditions sequenceNumberAccessConditions;
 
     private ModifiedAccessConditions modifiedAccessConditions;

--- a/src/main/java/com/microsoft/azure/storage/blob/PageBlobURL.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/PageBlobURL.java
@@ -159,7 +159,7 @@ public final class PageBlobURL extends BlobURL {
      */
     public Single<PageBlobCreateResponse> create(long size, Long sequenceNumber, BlobHTTPHeaders headers,
             Metadata metadata, BlobAccessConditions accessConditions, Context context) {
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
 
         if (size % PageBlobURL.PAGE_BYTES != 0) {
             // Throwing is preferred to Single.error because this will error out immediately instead of waiting until
@@ -171,7 +171,7 @@ public final class PageBlobURL extends BlobURL {
             // subscription.
             throw new IllegalArgumentException("SequenceNumber must be greater than or equal to 0.");
         }
-        metadata = metadata == null ? Metadata.NONE : metadata;
+        metadata = metadata == null ? new Metadata() : metadata;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedPageBlobs().createWithRestResponseAsync(
@@ -237,7 +237,7 @@ public final class PageBlobURL extends BlobURL {
      */
     public Single<PageBlobUploadPagesResponse> uploadPages(PageRange pageRange, Flowable<ByteBuffer> body,
             PageBlobAccessConditions pageBlobAccessConditions, Context context) {
-        pageBlobAccessConditions = pageBlobAccessConditions == null ? PageBlobAccessConditions.NONE :
+        pageBlobAccessConditions = pageBlobAccessConditions == null ? new PageBlobAccessConditions() :
                 pageBlobAccessConditions;
 
         if (pageRange == null) {
@@ -301,7 +301,7 @@ public final class PageBlobURL extends BlobURL {
      */
     public Single<PageBlobClearPagesResponse> clearPages(PageRange pageRange,
             PageBlobAccessConditions pageBlobAccessConditions, Context context) {
-        pageBlobAccessConditions = pageBlobAccessConditions == null ? PageBlobAccessConditions.NONE :
+        pageBlobAccessConditions = pageBlobAccessConditions == null ? new PageBlobAccessConditions() :
                 pageBlobAccessConditions;
         if (pageRange == null) {
             // Throwing is preferred to Single.error because this will error out immediately instead of waiting until
@@ -357,8 +357,8 @@ public final class PageBlobURL extends BlobURL {
      */
     public Single<PageBlobGetPageRangesResponse> getPageRanges(BlobRange blobRange,
             BlobAccessConditions accessConditions, Context context) {
-        blobRange = blobRange == null ? BlobRange.DEFAULT : blobRange;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        blobRange = blobRange == null ? new BlobRange() : blobRange;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedPageBlobs().getPageRangesWithRestResponseAsync(
@@ -414,8 +414,8 @@ public final class PageBlobURL extends BlobURL {
      */
     public Single<PageBlobGetPageRangesDiffResponse> getPageRangesDiff(BlobRange blobRange, String prevSnapshot,
             BlobAccessConditions accessConditions, Context context) {
-        blobRange = blobRange == null ? BlobRange.DEFAULT : blobRange;
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        blobRange = blobRange == null ? new BlobRange() : blobRange;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         if (prevSnapshot == null) {
@@ -473,7 +473,7 @@ public final class PageBlobURL extends BlobURL {
             // subscription.
             throw new IllegalArgumentException("size must be a multiple of PageBlobURL.PAGE_BYTES.");
         }
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(this.storageClient.generatedPageBlobs().resizeWithRestResponseAsync(
@@ -533,7 +533,7 @@ public final class PageBlobURL extends BlobURL {
             // subscription.
             throw new IllegalArgumentException("SequenceNumber must be greater than or equal to 0.");
         }
-        accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         sequenceNumber = action == SequenceNumberActionType.INCREMENT ? null : sequenceNumber;
         context = context == null ? Context.NONE : context;
 

--- a/src/main/java/com/microsoft/azure/storage/blob/PipelineOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/PipelineOptions.java
@@ -37,11 +37,11 @@ public final class PipelineOptions {
 
     private HttpPipelineLogger logger;
 
-    private RequestRetryOptions requestRetryOptions = RequestRetryOptions.DEFAULT;
+    private RequestRetryOptions requestRetryOptions = new RequestRetryOptions();
 
-    private LoggingOptions loggingOptions = LoggingOptions.DEFAULT;
+    private LoggingOptions loggingOptions = new LoggingOptions();
 
-    private TelemetryOptions telemetryOptions = TelemetryOptions.DEFAULT;
+    private TelemetryOptions telemetryOptions = new TelemetryOptions();
 
     /**
      * Returns a {@code PipelineOptions} object with default values for each of the options fields. An

--- a/src/main/java/com/microsoft/azure/storage/blob/RequestRetryFactory.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/RequestRetryFactory.java
@@ -47,7 +47,7 @@ public final class RequestRetryFactory implements RequestPolicyFactory {
      *         {@link RequestRetryOptions}
      */
     public RequestRetryFactory(RequestRetryOptions requestRetryOptions) {
-        this.requestRetryOptions = requestRetryOptions == null ? RequestRetryOptions.DEFAULT : requestRetryOptions;
+        this.requestRetryOptions = requestRetryOptions == null ? new RequestRetryOptions() : requestRetryOptions;
     }
 
     @Override

--- a/src/main/java/com/microsoft/azure/storage/blob/RequestRetryOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/RequestRetryOptions.java
@@ -23,12 +23,6 @@ import java.util.concurrent.TimeUnit;
  */
 public final class RequestRetryOptions {
 
-    /**
-     * An object representing default retry values: Exponential backoff, maxTries=4, tryTimeout=30, retryDelayInMs=4000,
-     * maxRetryDelayInMs=120000, secondaryHost=null.
-     */
-    public static final RequestRetryOptions DEFAULT = new RequestRetryOptions(RetryPolicyType.EXPONENTIAL, null,
-            null, null, null, null);
     final private int maxTries;
     final private int tryTimeout;
     final private long retryDelayInMs;
@@ -36,8 +30,17 @@ public final class RequestRetryOptions {
     /**
      * A {@link RetryPolicyType} telling the pipeline what kind of retry policy to use.
      */
-    private RetryPolicyType retryPolicyType = RetryPolicyType.EXPONENTIAL;
+    private RetryPolicyType retryPolicyType;
     private String secondaryHost;
+
+    /**
+     * Constructor with default retry values: Exponential backoff, maxTries=4, tryTimeout=30, retryDelayInMs=4000,
+     * maxRetryDelayInMs=120000, secondaryHost=null.
+     */
+    public RequestRetryOptions() {
+        this(RetryPolicyType.EXPONENTIAL, null,
+                null, null, null, null);
+    }
 
     /**
      * Configures how the {@link com.microsoft.rest.v2.http.HttpPipeline} should retry requests.

--- a/src/main/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValues.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ServiceSASSignatureValues.java
@@ -353,7 +353,7 @@ public final class ServiceSASSignatureValues {
                 this.expiryTime == null ? "" : Utility.ISO8601UTCDateFormatter.format(this.expiryTime),
                 getCanonicalName(sharedKeyCredentials.getAccountName()),
                 this.identifier == null ? "" : this.identifier,
-                this.ipRange == null ? IPRange.DEFAULT.toString() : this.ipRange.toString(),
+                this.ipRange == null ? (new IPRange()).toString() : this.ipRange.toString(),
                 this.protocol == null ? "" : protocol.toString(),
                 this.version,
                 this.cacheControl == null ? "" : this.cacheControl,

--- a/src/main/java/com/microsoft/azure/storage/blob/ServiceURL.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/ServiceURL.java
@@ -131,7 +131,7 @@ public final class ServiceURL extends StorageURL {
      */
     public Single<ServiceListContainersSegmentResponse> listContainersSegment(String marker,
             ListContainersOptions options, Context context) {
-        options = options == null ? ListContainersOptions.DEFAULT : options;
+        options = options == null ? new ListContainersOptions() : options;
         context = context == null ? Context.NONE : context;
 
         return addErrorWrappingToSingle(

--- a/src/main/java/com/microsoft/azure/storage/blob/TelemetryFactory.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/TelemetryFactory.java
@@ -42,7 +42,7 @@ public final class TelemetryFactory implements RequestPolicyFactory {
      *         {@link TelemetryOptions}
      */
     public TelemetryFactory(TelemetryOptions telemetryOptions) {
-        telemetryOptions = telemetryOptions == null ? TelemetryOptions.DEFAULT : telemetryOptions;
+        telemetryOptions = telemetryOptions == null ? new TelemetryOptions() : telemetryOptions;
         String userAgentPrefix = telemetryOptions.userAgentPrefix() == null ?
                 Constants.EMPTY_STRING : telemetryOptions.userAgentPrefix();
         this.userAgent = userAgentPrefix + ' ' +

--- a/src/main/java/com/microsoft/azure/storage/blob/TelemetryOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/TelemetryOptions.java
@@ -19,9 +19,11 @@ package com.microsoft.azure.storage.blob;
  */
 public final class TelemetryOptions {
 
-    public static final TelemetryOptions DEFAULT = new TelemetryOptions(Constants.EMPTY_STRING);
-
     private final String userAgentPrefix;
+
+    public TelemetryOptions() {
+        this(Constants.EMPTY_STRING);
+    }
 
     /**
      * @param userAgentPrefix

--- a/src/main/java/com/microsoft/azure/storage/blob/TransferManager.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/TransferManager.java
@@ -75,7 +75,7 @@ public final class TransferManager {
         Utility.assertNotNull("blockBlobURL", blockBlobURL);
         Utility.assertInBounds("blockLength", blockLength, 1, BlockBlobURL.MAX_STAGE_BLOCK_BYTES);
         TransferManagerUploadToBlockBlobOptions optionsReal = options == null ?
-                TransferManagerUploadToBlockBlobOptions.DEFAULT : options;
+                new TransferManagerUploadToBlockBlobOptions() : options;
 
 
         // If the size of the file can fit in a single upload, do it this way.
@@ -174,9 +174,9 @@ public final class TransferManager {
      */
     public static Single<BlobDownloadHeaders> downloadBlobToFile(AsynchronousFileChannel file, BlobURL blobURL,
             BlobRange range, TransferManagerDownloadFromBlobOptions options) {
-        BlobRange r = range == null ? BlobRange.DEFAULT : range;
+        BlobRange r = range == null ? new BlobRange() : range;
         TransferManagerDownloadFromBlobOptions o = options == null ?
-                TransferManagerDownloadFromBlobOptions.DEFAULT : options;
+                new TransferManagerDownloadFromBlobOptions() : options;
         Utility.assertNotNull("blobURL", blobURL);
         Utility.assertNotNull("file", file);
 

--- a/src/main/java/com/microsoft/azure/storage/blob/TransferManagerDownloadFromBlobOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/TransferManagerDownloadFromBlobOptions.java
@@ -20,12 +20,6 @@ package com.microsoft.azure.storage.blob;
  */
 public final class TransferManagerDownloadFromBlobOptions {
 
-    /**
-     * The default download options.
-     */
-    public static final TransferManagerDownloadFromBlobOptions DEFAULT =
-            new TransferManagerDownloadFromBlobOptions(null, null, null, null, null);
-
     private final long chunkSize;
 
     private final IProgressReceiver progressReceiver;
@@ -36,6 +30,10 @@ public final class TransferManagerDownloadFromBlobOptions {
 
     // Cannot be final because we may have to set this property in order to lock on the etag.
     private BlobAccessConditions accessConditions;
+
+    public TransferManagerDownloadFromBlobOptions() {
+        this(null, null, null, null, null);
+    }
 
     /**
      * Returns an object that configures the parallel download behavior for methods on the {@link TransferManager}.
@@ -77,7 +75,7 @@ public final class TransferManagerDownloadFromBlobOptions {
             this.parallelism = Constants.TRANSFER_MANAGER_DEFAULT_PARALLELISM;
         }
 
-        this.accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        this.accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
         this.reliableDownloadOptionsPerBlock = reliableDownloadOptions == null ?
                 new ReliableDownloadOptions() : reliableDownloadOptions;
     }

--- a/src/main/java/com/microsoft/azure/storage/blob/TransferManagerUploadToBlockBlobOptions.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/TransferManagerUploadToBlockBlobOptions.java
@@ -22,12 +22,6 @@ import com.microsoft.azure.storage.blob.models.BlobHTTPHeaders;
  */
 public class TransferManagerUploadToBlockBlobOptions {
 
-    /**
-     * An object which represents the default parallel upload options.
-     */
-    public static final TransferManagerUploadToBlockBlobOptions DEFAULT = new TransferManagerUploadToBlockBlobOptions(
-            null, null, null, null, null);
-
     private final IProgressReceiver progressReceiver;
 
     private final BlobHTTPHeaders httpHeaders;
@@ -37,6 +31,10 @@ public class TransferManagerUploadToBlockBlobOptions {
     private final BlobAccessConditions accessConditions;
 
     private final int parallelism;
+
+    public TransferManagerUploadToBlockBlobOptions() {
+        this(null, null, null, null, null);
+    }
 
     /**
      * Creates a new object that configures the parallel upload behavior. Null may be passed to accept the default
@@ -72,7 +70,7 @@ public class TransferManagerUploadToBlockBlobOptions {
 
         this.httpHeaders = httpHeaders;
         this.metadata = metadata;
-        this.accessConditions = accessConditions == null ? BlobAccessConditions.NONE : accessConditions;
+        this.accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
     }
 
     /**

--- a/src/test/java/com/microsoft/azure/storage/Samples.java
+++ b/src/test/java/com/microsoft/azure/storage/Samples.java
@@ -305,7 +305,7 @@ public class Samples {
             The presence of the marker indicates that there are more blobs to list, so we make another call to
             listContainersSegment and pass the result through this helper function.
              */
-            return serviceURL.listContainersSegment(nextMarker, ListContainersOptions.DEFAULT, null)
+            return serviceURL.listContainersSegment(nextMarker, new ListContainersOptions(), null)
                     .flatMap(containersListBlobHierarchySegmentResponse ->
                             listContainersHelper(serviceURL, response));
         }
@@ -1423,7 +1423,7 @@ public class Samples {
                         // Upload some data to a blob
                         Single.using(() -> AsynchronousFileChannel.open(file.toPath()),
                                 fileChannel -> TransferManager.uploadFileToBlockBlob(fileChannel, blobURL,
-                                        BlockBlobURL.MAX_STAGE_BLOCK_BYTES, TransferManagerUploadToBlockBlobOptions.DEFAULT),
+                                        BlockBlobURL.MAX_STAGE_BLOCK_BYTES, new TransferManagerUploadToBlockBlobOptions()),
                                 AsynchronousFileChannel::close))
                 .flatMap(response ->
                         blobURL.download(null, null, false, null))
@@ -2158,7 +2158,7 @@ public class Samples {
         // </service_stats>
 
         // <service_list>
-        serviceURL.listContainersSegment(null, ListContainersOptions.DEFAULT, null)
+        serviceURL.listContainersSegment(null, new ListContainersOptions(), null)
                 .flatMap(listContainersSegmentResponse ->
                         // The asynchronous requests require we use recursion to continue our listing.
                         listContainersHelper(serviceURL, listContainersSegmentResponse))


### PR DESCRIPTION
… with defaults
- Removed DEFAULT and NONE static variables. Empty constructors should be used instead. DEFAULT static values were error prone and unsafe to use because although the field was final, the objects were mutable, so it was possible the value could be changed accidentally and alter the behavior of the program.