### PR TITLE
Fix logging error when java.io.tmpdir has no trailing separator

### DIFF
--- a/src/main/java/com/microsoft/azure/storage/blob/LoggingFactory.java
+++ b/src/main/java/com/microsoft/azure/storage/blob/LoggingFactory.java
@@ -54,7 +54,7 @@ public final class LoggingFactory implements RequestPolicyFactory {
             forceLogger.setLevel(Level.WARNING);
 
             // Create the logs directory if it doesn't exist.
-            File logDir = new File(System.getProperty("java.io.tmpdir") + "AzureStorageJavaSDKLogs");
+            File logDir = new File(System.getProperty("java.io.tmpdir"), "AzureStorageJavaSDKLogs");
             if (!logDir.exists()) {
                 if (!logDir.mkdir()) {
                     throw new Exception("Could not create logs directory");


### PR DESCRIPTION
If the system property `java.io.tmpdir` does not end with a trailing separator, the directory for logs is created incorrectly.  In particular, if `java.io.tmpdir` is set to e.g. `./tmp`, the directory created will be called `tmpAzureStorageJavaSDKLogs`, and the logger will attempt to use `tmp/AzureStorageJavaSDKLogs`.
In this case a the following is logged:

    Azure Storage default logging could not be configured due to the following exception: java.nio.file.NoSuchFileException: /Users/ataylor/dev/test/tmp/AzureStorageJavaSDKLogs/00.lck

The fix is to use the `File(String, String)` constructor, which handles the cases with and without a separator correctly.
 
This is https://github.com/Azure/azure-storage-java/pull/413 redone against the dev branch.