### PR TITLE
Updated BlobRequestOptions.java

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobRequestOptions.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobRequestOptions.java
@@ -443,7 +443,7 @@ public final class BlobRequestOptions extends RequestOptions {
     /**
      * Sets the threshold size used for writing a single blob to use.
      * <p>
-     * The default threshold size is set in the client and is by default 32MB. You can change the threshold size on this
+     * The default threshold size is set in the client and is by default 132MB. You can change the threshold size on this
      * request by setting this property. You can also change the value on the
      * {@link CloudBlobClient#getDefaultRequestOptions()} object so that all subsequent requests made via the service
      * client will use that threshold size.


### PR DESCRIPTION
singleBlobPutThresholdInBytes property default size is mentioned as 32 MB.

The default threshold size is set in the client and is by default 32MB. You can change the threshold size on this
request by setting this property.

I have updated this one to 132 MB.
As per the discussion I had with MSFT Storage SMEs, this is a documentation bug.

(256 * 1024 * 1024) / 2 = 134217728‬, this is what the default threshold size is coming.

Follow below Teams link for more details:
https://teams.microsoft.com/l/message/19:3e1c65a38017478b86ad318bf03a1f65@thread.skype/1576580014301?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=8a6a0fe1-0d7d-41a0-93f0-0fd7af9ac2c8&parentMessageId=1576505277402&teamName=PaaS%20Developer%20POD%20Global&channelName=Storage&createdTime=1576580014301