### PR TITLE
Fix for keepalivesocketfactory regression

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
@@ -108,7 +108,7 @@ public abstract class RequestOptions {
         }
 
         if (modifiedOptions.disableHttpsSocketKeepAlive() == null) {
-            modifiedOptions.setDisableHttpsSocketKeepAlive(true);
+            modifiedOptions.setDisableHttpsSocketKeepAlive(false);
         }
     }
 
@@ -322,16 +322,16 @@ public abstract class RequestOptions {
      * Sets a value to indicate whether https socket keep-alive should be disabled. Use <code>true</code> to disable
      * keep-alive; otherwise, <code>false</code>
      * <p>
-     * The default is set in the client and is by default true, indicating that https socket keep-alive will be
-     * disabled. You can change the value on this request by setting this property. You can also change the value on
+     * The default is set in the client and is by default false, indicating that https socket keep-alive will be
+     * enabled. You can change the value on this request by setting this property. You can also change the value on
      * on the {@link ServiceClient#getDefaultRequestOptions()} object so that all subsequent requests made via the
      * service client will use the appropriate value.
      * <p>
      * Setting keep-alive on https sockets is to work around a bug in the JVM where connection timeouts are not honored
-     * on retried requests. In those cases, you may choose to use socket keep-alive as a fallback. Unfortunately, the
-     * timeout value must be taken from a JVM property rather than configured locally. Therefore, in rare cases the JVM
-     * has configured aggressively short keep-alive times, it may not be beneficial to enable the use of keep-alives
-     * lest they interfere with long running data transfer operations.
+     * on retried requests. In those cases, we use socket keep-alive as a fallback. Unfortunately, the timeout value
+     * must be taken from a JVM property rather than configured locally. Therefore, in rare cases the JVM has configured
+     * aggressively short keep-alive times, it may be beneficial to disable the use of keep-alives lest they interfere
+     * with long running data transfer operations.
      *
      * @param disableHttpsSocketKeepAlive
      *           A value to indicate whether https socket keep-alive should be disabled.

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/RequestOptions.java
@@ -108,7 +108,7 @@ public abstract class RequestOptions {
         }
 
         if (modifiedOptions.disableHttpsSocketKeepAlive() == null) {
-            modifiedOptions.setDisableHttpsSocketKeepAlive(false);
+            modifiedOptions.setDisableHttpsSocketKeepAlive(true);
         }
     }
 
@@ -322,16 +322,16 @@ public abstract class RequestOptions {
      * Sets a value to indicate whether https socket keep-alive should be disabled. Use <code>true</code> to disable
      * keep-alive; otherwise, <code>false</code>
      * <p>
-     * The default is set in the client and is by default false, indicating that https socket keep-alive will be
-     * enabled. You can change the value on this request by setting this property. You can also change the value on
+     * The default is set in the client and is by default true, indicating that https socket keep-alive will be
+     * disabled. You can change the value on this request by setting this property. You can also change the value on
      * on the {@link ServiceClient#getDefaultRequestOptions()} object so that all subsequent requests made via the
      * service client will use the appropriate value.
      * <p>
      * Setting keep-alive on https sockets is to work around a bug in the JVM where connection timeouts are not honored
-     * on retried requests. In those cases, we use socket keep-alive as a fallback. Unfortunately, the timeout value
-     * must be taken from a JVM property rather than configured locally. Therefore, in rare cases the JVM has configured
-     * aggressively short keep-alive times, it may be beneficial to disable the use of keep-alives lest they interfere
-     * with long running data transfer operations.
+     * on retried requests. In those cases, you may choose to use socket keep-alive as a fallback. Unfortunately, the
+     * timeout value must be taken from a JVM property rather than configured locally. Therefore, in rare cases the JVM
+     * has configured aggressively short keep-alive times, it may not be beneficial to enable the use of keep-alives
+     * lest they interfere with long running data transfer operations.
      *
      * @param disableHttpsSocketKeepAlive
      *           A value to indicate whether https socket keep-alive should be disabled.

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/BaseRequest.java
@@ -230,7 +230,7 @@ public final class BaseRequest {
          */
         if (retConnection instanceof HttpsURLConnection && !options.disableHttpsSocketKeepAlive()) {
             HttpsURLConnection httpsConnection = ((HttpsURLConnection) retConnection);
-            httpsConnection.setSSLSocketFactory(new KeepAliveSocketFactory(httpsConnection.getSSLSocketFactory()));
+            httpsConnection.setSSLSocketFactory(KeepAliveSocketFactory.getInstance());
         }
 
         /*

--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/KeepAliveSocketFactory.java
@@ -15,6 +15,7 @@
 
 package com.microsoft.azure.storage.core;
 
+import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -39,8 +40,14 @@ import java.net.UnknownHostException;
 public class KeepAliveSocketFactory extends SSLSocketFactory {
     private SSLSocketFactory delegate;
 
+    private static final KeepAliveSocketFactory singletonKeepAliveSocketFactory = new KeepAliveSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
+
     KeepAliveSocketFactory(SSLSocketFactory delegate) {
         this.delegate = delegate;
+    }
+
+    public static KeepAliveSocketFactory getInstance() {
+        return singletonKeepAliveSocketFactory;
     }
 
     @Override


### PR DESCRIPTION
This PR introduces the following changes:

- `KeepAliveSocketFactory` is changed to follow the singleton pattern, and the instance is initialized early
- Changed `createURLConnection` in `BaseRequest` to properly get the `KeepAliveSocketFactory` instance when https keepalive is enabled
- Re-enabled https socket keepalive by default
- Changed the comments in `RequestOptions` to reflect the changed default value for `disableHttpsKeepAlive`

One possible issue is thread-safety of the `KeepAliveSocketFactory` class. Specifically, do you think we should take further steps to ensure that the `createSocket` methods are thread safe? Any other concerns?