### PR TITLE
Speed up WrappedByteArrayOutputStream

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/core/WrappedByteArrayOutputStream.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/core/WrappedByteArrayOutputStream.java
@@ -46,4 +46,14 @@ public class WrappedByteArrayOutputStream extends OutputStream {
         this.buffer[this.offset] = (byte) b;
         this.offset++;
     }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (this.offset + len > this.buffer.length) {
+            throw new IOException(SR.CONTENT_LENGTH_MISMATCH);
+        }
+
+        System.arraycopy(b, off, this.buffer, this.offset, len);
+        this.offset += len;
+    }
 }


### PR DESCRIPTION
This stream is used in downloading to a byte array and forced any data
downloaded to run through a hot byte-byte copy loop taking up to 15%
of the runtime when downloading a blob in profiling.