### PR TITLE
Fixed on reading un-encoded copy-source header field

### DIFF
--- a/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobResponse.java
+++ b/microsoft-azure-storage/src/com/microsoft/azure/storage/blob/BlobResponse.java
@@ -59,7 +59,7 @@ final class BlobResponse extends BaseResponse {
      * @throws URISyntaxException
      */
     public static BlobAttributes getBlobAttributes(final HttpURLConnection request, final StorageUri resourceURI,
-            final String snapshotID) throws URISyntaxException, ParseException {
+            final String snapshotID) throws URISyntaxException, ParseException, StorageException {
 
         final String blobType = request.getHeaderField(BlobConstants.BLOB_TYPE_HEADER);
         final BlobAttributes attributes = new BlobAttributes(BlobType.parse(blobType));
@@ -268,7 +268,7 @@ final class BlobResponse extends BaseResponse {
      * @throws URISyntaxException
      * @throws ParseException
      */
-    public static CopyState getCopyState(final HttpURLConnection request) throws URISyntaxException, ParseException {
+    public static CopyState getCopyState(final HttpURLConnection request) throws URISyntaxException, ParseException, StorageException {
         String copyStatusString = request.getHeaderField(Constants.HeaderConstants.COPY_STATUS);
         if (!Utility.isNullOrEmpty(copyStatusString)) {
             final CopyState copyState = new CopyState();
@@ -286,7 +286,7 @@ final class BlobResponse extends BaseResponse {
 
             final String copySourceString = request.getHeaderField(Constants.HeaderConstants.COPY_SOURCE);
             if (!Utility.isNullOrEmpty(copySourceString)) {
-                copyState.setSource(new URI(copySourceString));
+                copyState.setSource(new URI(Utility.safeEncode(copySourceString)));
             }
 
             final String copyCompletionTimeString =


### PR DESCRIPTION
Copy-source property can be stored un-encoded in the blob storage. We need to encode the property while reading it so that `getBlobAttributes` is not throwing an exception in such a case.

To reproduce the bug:
* Create a file in the blob storage with a space in the filename.
* Copy the file to another target using the COPY Blob API (Copy Blob (REST API) - Azure Storage | Microsoft Docs, make sure to not escape the x-ms-copy-source header while sending the request). Here is the sample of HTTP PUT request to do the copy:
```
PUT /path/to/your_copied_file HTTP/1.1
Host: YOUR_STORAGE_ACCOUNT.blob.core.windows.net
Authorization: Bearer YOUR_BEARER_TOKEN
x-ms-version: 2020-08-04
x-ms-copy-source-authorization: Bearer YOUR_BEARER_TOKEN
x-ms-copy-source: https://YOUR_STORAGE_ACCOUNT.blob.core.windows.net/path/to/your sample file with space
```
* Try to execute `CloudBlob.downloadAttributes` on the copied file.